### PR TITLE
Fix category reset on map pages

### DIFF
--- a/frontend/src/components/HomePage/GenericMapPage.jsx
+++ b/frontend/src/components/HomePage/GenericMapPage.jsx
@@ -580,12 +580,17 @@ const GenericMapPage = ({ apiUrl }) => {
     const [hasInitialLoad, setHasInitialLoad] = useState(false);
     const [selectedCategory, setSelectedCategory] = useState(null);
     const [showGentleLoading, setShowGentleLoading] = useState(false);
-    
+
     const boundsTimeout = useRef(null);
     const lastFetchedBounds = useRef(null);
     const cacheRef = useRef(new Map());
     const { t, i18n } = useTranslation();
     const navigate = useNavigate();
+
+    // Reset selected category whenever content type changes
+    useEffect(() => {
+        setSelectedCategory(null);
+    }, [contentType]);
 
     // Memoized base URL
     const baseUrl = useMemo(() => import.meta.env.VITE_API_URL, []);
@@ -861,7 +866,6 @@ const GenericMapPage = ({ apiUrl }) => {
     const handleCategoryLabelClick = (cat) => {
         if (selectedCategory === cat) {
             setSelectedCategory(null);
-            handleClearFilters();
         } else {
             setSelectedCategory(cat);
             // Filter by category only


### PR DESCRIPTION
## Summary
- ensure category selection resets when switching between rentals and services
- avoid clearing filters when clicking an already active category

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688769f257bc8331aa0905cb9af7bb82