### PR TITLE
Add React Native skeleton

### DIFF
--- a/frontend-native/App.js
+++ b/frontend-native/App.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { AuthProvider } from './src/context/AuthContext';
+import RentalsMapPage from './src/screens/RentalsMapPage';
+import ServicesMapPage from './src/screens/ServicesMapPage';
+import Account from './src/screens/Account';
+import Dashboard from './src/screens/Dashboard';
+import EditProfile from './src/screens/EditProfile';
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <AuthProvider>
+      <NavigationContainer>
+        <Stack.Navigator initialRouteName="Rentals">
+          <Stack.Screen name="Rentals" component={RentalsMapPage} />
+          <Stack.Screen name="Services" component={ServicesMapPage} />
+          <Stack.Screen name="Account" component={Account} />
+          <Stack.Screen name="Dashboard" component={Dashboard} />
+          <Stack.Screen name="EditProfile" component={EditProfile} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </AuthProvider>
+  );
+}

--- a/frontend-native/README.md
+++ b/frontend-native/README.md
@@ -1,0 +1,5 @@
+# GiveIt React Native
+
+This directory contains an experimental React Native port of the GiveIt frontend.
+It uses Expo and React Navigation. Only minimal placeholder screens are included
+and most web specific functionality has not been implemented yet.

--- a/frontend-native/package.json
+++ b/frontend-native/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "giveit-native",
+  "private": true,
+  "version": "0.1.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^50.0.0",
+    "react": "18.2.0",
+    "react-native": "0.73.0",
+    "@react-navigation/native": "^6.2.0",
+    "@react-navigation/native-stack": "^6.9.0"
+  }
+}

--- a/frontend-native/src/context/AuthContext.js
+++ b/frontend-native/src/context/AuthContext.js
@@ -1,0 +1,25 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const AuthContext = createContext();
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null);
+
+  // Placeholder login function
+  const login = async (email, password) => {
+    // TODO: integrate Firebase or other auth provider
+    setUser({ email });
+  };
+
+  const logout = async () => {
+    setUser(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export const useAuthContext = () => useContext(AuthContext);

--- a/frontend-native/src/screens/Account.js
+++ b/frontend-native/src/screens/Account.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function Account() {
+  return (
+    <View style={styles.container}>
+      <Text>Account - TODO: implement</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});

--- a/frontend-native/src/screens/Dashboard.js
+++ b/frontend-native/src/screens/Dashboard.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function Dashboard() {
+  return (
+    <View style={styles.container}>
+      <Text>Dashboard - TODO: implement</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});

--- a/frontend-native/src/screens/EditProfile.js
+++ b/frontend-native/src/screens/EditProfile.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function EditProfile() {
+  return (
+    <View style={styles.container}>
+      <Text>EditProfile - TODO: implement</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});

--- a/frontend-native/src/screens/RentalsMapPage.js
+++ b/frontend-native/src/screens/RentalsMapPage.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function RentalsMapPage() {
+  return (
+    <View style={styles.container}>
+      <Text>RentalsMapPage - TODO: implement</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});

--- a/frontend-native/src/screens/ServicesMapPage.js
+++ b/frontend-native/src/screens/ServicesMapPage.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function ServicesMapPage() {
+  return (
+    <View style={styles.container}>
+      <Text>ServicesMapPage - TODO: implement</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});


### PR DESCRIPTION
## Summary
- set up initial React Native project in **frontend-native** using Expo and React Navigation
- add basic `AuthContext` and placeholder screens
- wire up navigation in `App.js`

## Testing
- `npm run lint` in `frontend`
- `npm run build` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6887a646310c8331a91c62bb7c13cdab