### PR TITLE
Revert dynamic TabBar styling

### DIFF
--- a/frontend/src/components/HomePage/TabBar.jsx
+++ b/frontend/src/components/HomePage/TabBar.jsx
@@ -5,8 +5,6 @@ import '../../styles/HomePage/TabBar.css';
 
 const TabBar = ({ activeTab, onTabChange, tabs }) => {
     const activeIndex = tabs.findIndex(tab => tab.id === activeTab);
-    const isWanted = activeTab.includes('request');
-    const indicatorColor = isWanted ? 'var(--listing-wanted)' : 'var(--listing-available)';
     const indicatorTransform = `translateX(${activeIndex * 100}%)`;
 
 
@@ -15,8 +13,6 @@ const TabBar = ({ activeTab, onTabChange, tabs }) => {
             <div className="tab-bar">
             {tabs.map((tab) => {
                 const isActive = activeTab === tab.id;
-                const isTabWanted = tab.id.includes('request');
-                const activeColor = isTabWanted ? 'var(--listing-wanted)' : 'var(--listing-available)';
                 return (
                     <button
                         key={tab.id}
@@ -26,7 +22,6 @@ const TabBar = ({ activeTab, onTabChange, tabs }) => {
                                 onTabChange(tab.id);
                             }
                         }}
-                        style={isActive ? { color: activeColor } : undefined}
                     >
                         {tab.label}
                     </button>
@@ -36,8 +31,7 @@ const TabBar = ({ activeTab, onTabChange, tabs }) => {
             <div
                 className="tab-indicator"
                 style={{
-                    transform: indicatorTransform,
-                    backgroundColor: indicatorColor
+                    transform: indicatorTransform
                 }}
             />
         </div>

--- a/frontend/src/components/MyItems/ModalCard.jsx
+++ b/frontend/src/components/MyItems/ModalCard.jsx
@@ -70,56 +70,35 @@ const ModalCard = ({ item, onDeleteSuccess, onEditSuccess, type = 'rental' }) =>
                 className="rental-card"
                 onClick={() => setShowDetails(true)}
                 dir={isRTL ? 'rtl' : 'ltr'}
-                style={{
-                    background: '#fff',
-                    borderRadius: 16,
-                    boxShadow: '0 2px 12px rgba(60,72,88,0.10)',
-                    padding: 20,
-                    margin: '12px 0',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'center',
-                    cursor: 'pointer',
-                    transition: 'box-shadow 0.2s, transform 0.2s',
-                }}
+               
                 onMouseOver={e => { e.currentTarget.style.boxShadow = '0 4px 20px rgba(38,166,154,0.18)'; e.currentTarget.style.transform = 'translateY(-2px)'; }}
                 onMouseOut={e => { e.currentTarget.style.boxShadow = '0 2px 12px rgba(60,72,88,0.10)'; e.currentTarget.style.transform = 'none'; }}
             >
-                <div style={{ width: 80, height: 80, borderRadius: 12, overflow: 'hidden', background: '#F4F6F8', display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 12 }}>
+                <div>
                     {Array.isArray(item.images) && item.images.length > 0 && item.images[0] ? (
                         <img
                             src={`https://giveit-backend.onrender.com${item.images[0]}`}
                             alt={item.title}
-                            style={{ width: 80, height: 80, objectFit: 'cover', borderRadius: 12 }}
+                           
                             onError={e => { e.target.onerror = null; e.target.src = ''; e.target.parentNode.innerHTML = placeholderSVG; }}
                         />
                     ) : (
                         <span dangerouslySetInnerHTML={{ __html: placeholderSVG }} />
                     )}
                 </div>
-                <h3 style={{ fontFamily: 'Heebo, Arial, sans-serif', fontSize: 18, fontWeight: 700, color: '#1C2526', margin: '0 0 6px', textAlign: isRTL ? 'right' : 'left', width: '100%' }}>{item.title}</h3>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6, width: '100%', justifyContent: isRTL ? 'flex-end' : 'flex-start' }}>
-                    <span style={{
-                        background: active ? '#C8E6C9' : '#ECEFF1',
-                        color: active ? '#388E3C' : '#607D8B',
-                        borderRadius: 8,
-                        padding: '2px 10px',
-                        fontSize: 13,
-                        fontWeight: 600,
-                        display: 'inline-block',
-                    }}>
+                <h3>{item.title}</h3>
+                <div>
+                    <span>
                         {active ? t('common.available') : t('common.not_available')}
                     </span>
                 </div>
-                <div style={{ fontFamily: 'Heebo, Arial, sans-serif', fontSize: 15, color: '#607D8B', marginBottom: 8, width: '100%', textAlign: isRTL ? 'right' : 'left' }}>
+                <div>
                     {item.price}₪ / {translatePricePeriod(item.pricePeriod)}
                 </div>
-                <div className="card-actions" style={{ display: 'flex', gap: 10, marginTop: 8, width: '100%', justifyContent: isRTL ? 'flex-end' : 'flex-start' }}>
+                <div className="card-actions">
                     <button
                         className="toggle-view-btn"
-                        style={{
-                            background: '#E3F2FD', color: '#1976D2', border: 'none', borderRadius: 20, padding: '6px 14px', fontSize: 14, fontWeight: 500, display: 'flex', alignItems: 'center', gap: 5, cursor: 'pointer', transition: 'background 0.2s',
-                        }}
+                       
                         onClick={e => { e.stopPropagation(); setShowEditModal(true); }}
                         aria-label={t('common.edit')}
                     >
@@ -127,9 +106,7 @@ const ModalCard = ({ item, onDeleteSuccess, onEditSuccess, type = 'rental' }) =>
                     </button>
                     <button
                         className="toggle-view-btn"
-                        style={{
-                            background: '#FFEBEE', color: '#D32F2F', border: 'none', borderRadius: 20, padding: '6px 14px', fontSize: 14, fontWeight: 500, display: 'flex', alignItems: 'center', gap: 5, cursor: 'pointer', transition: 'background 0.2s',
-                        }}
+                       
                         onClick={e => { e.stopPropagation(); setShowDeleteConfirm(true); }}
                         aria-label={t('common.delete')}
                     >
@@ -137,9 +114,7 @@ const ModalCard = ({ item, onDeleteSuccess, onEditSuccess, type = 'rental' }) =>
                     </button>
                     <button
                         className="toggle-view-btn"
-                        style={{
-                            background: active ? '#C8E6C9' : '#ECEFF1', color: active ? '#388E3C' : '#607D8B', border: 'none', borderRadius: 20, padding: '6px 14px', fontSize: 14, fontWeight: 500, display: 'flex', alignItems: 'center', gap: 5, cursor: 'pointer', transition: 'background 0.2s',
-                        }}
+                       
                         onClick={e => { e.stopPropagation(); handleToggleStatus(); }}
                         aria-label={active ? t('common.mark_unavailable') : t('common.mark_available')}
                     >
@@ -149,28 +124,28 @@ const ModalCard = ({ item, onDeleteSuccess, onEditSuccess, type = 'rental' }) =>
             </div>
 
             {showDetails && (
-                <div className="rental-card-modal" onClick={() => setShowDetails(false)} style={{ position: 'fixed', top: 0, left: 0, width: '100vw', height: '100vh', background: 'rgba(44,62,80,0.18)', zIndex: 1000, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                    <div className="rental-card-modal-content" onClick={e => e.stopPropagation()} dir={isRTL ? 'rtl' : 'ltr'} style={{ background: '#fff', borderRadius: 18, padding: 32, maxWidth: 400, width: '90vw', boxShadow: '0 4px 32px rgba(38,166,154,0.18)', position: 'relative', fontFamily: 'Heebo, Arial, sans-serif' }}>
-                        <button onClick={() => setShowDetails(false)} style={{ position: 'absolute', top: 12, right: 12, background: '#ECEFF1', border: 'none', borderRadius: '50%', width: 32, height: 32, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 18, cursor: 'pointer' }} aria-label="close">✖️</button>
-                        <h2 style={{ fontSize: 22, fontWeight: 700, margin: '0 0 12px', color: '#1C2526', textAlign: isRTL ? 'right' : 'left' }}>{item.title}</h2>
-                        <div style={{ width: 120, height: 120, borderRadius: 16, overflow: 'hidden', background: '#F4F6F8', display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto 18px' }}>
+                <div className="rental-card-modal" onClick={() => setShowDetails(false)}>
+                    <div className="rental-card-modal-content" onClick={e => e.stopPropagation()} dir={isRTL ? 'rtl' : 'ltr'}>
+                        <button onClick={() => setShowDetails(false)} aria-label="close">✖️</button>
+                        <h2>{item.title}</h2>
+                        <div>
                             {Array.isArray(item.images) && item.images.length > 0 && item.images[0] ? (
                                 <img
                                     src={`https://giveit-backend.onrender.com${item.images[0]}`}
                                     alt={item.title}
-                                    style={{ width: 120, height: 120, objectFit: 'cover', borderRadius: 16 }}
+                                   
                                     onError={e => { e.target.onerror = null; e.target.src = ''; e.target.parentNode.innerHTML = placeholderSVG; }}
                                 />
                             ) : (
                                 <span dangerouslySetInnerHTML={{ __html: placeholderSVG }} />
                             )}
                         </div>
-                        <div style={{ fontSize: 15, color: '#607D8B', marginBottom: 10, textAlign: isRTL ? 'right' : 'left' }}><strong>{t('common.description')}:</strong> {item.description}</div>
-                        <div style={{ fontSize: 15, color: '#607D8B', marginBottom: 6, textAlign: isRTL ? 'right' : 'left' }}><strong>{t('common.category')}:</strong> {item.category}</div>
-                        <div style={{ fontSize: 15, color: '#607D8B', marginBottom: 6, textAlign: isRTL ? 'right' : 'left' }}><strong>{t('common.phone')}:</strong> {item.phone}</div>
-                        <div style={{ fontSize: 15, color: '#607D8B', marginBottom: 6, textAlign: isRTL ? 'right' : 'left' }}><strong>{t('common.price')}:</strong> {item.price}₪ / {translatePricePeriod(item.pricePeriod)}</div>
-                        <div style={{ fontSize: 15, color: '#607D8B', marginBottom: 6, textAlign: isRTL ? 'right' : 'left' }}><strong>{t('common.city')}:</strong> {item.city}</div>
-                        <div style={{ fontSize: 15, color: '#607D8B', marginBottom: 6, textAlign: isRTL ? 'right' : 'left' }}><strong>{t('common.street')}:</strong> {item.street}</div>
+                        <div><strong>{t('common.description')}:</strong> {item.description}</div>
+                        <div><strong>{t('common.category')}:</strong> {item.category}</div>
+                        <div><strong>{t('common.phone')}:</strong> {item.phone}</div>
+                        <div><strong>{t('common.price')}:</strong> {item.price}₪ / {translatePricePeriod(item.pricePeriod)}</div>
+                        <div><strong>{t('common.city')}:</strong> {item.city}</div>
+                        <div><strong>{t('common.street')}:</strong> {item.street}</div>
                     </div>
                 </div>
             )}

--- a/frontend/src/components/MyItems/MyModals.jsx
+++ b/frontend/src/components/MyItems/MyModals.jsx
@@ -24,7 +24,6 @@ const MyItemCard = ({ item, isRTL, view, t, setEditTarget, setDeleteTarget, plac
                         src={imageUrl}
                         alt={item.title}
                         className="myitems-card-img"
-                        style={{ border: '2px solid #607D8B', borderRadius: 8, width: 72, height: 64, objectFit: 'cover', background: '#F4F6F8' }}
                         onError={() => setImgError(true)}
                     />
                 ) : (
@@ -32,31 +31,20 @@ const MyItemCard = ({ item, isRTL, view, t, setEditTarget, setDeleteTarget, plac
                 )}
             </div>
             <div className="myitems-card-content">
-                <div className="myitems-card-title" style={{ fontFamily: 'Heebo, Arial, sans-serif', fontSize: 15, color: '#1C2526', direction: isRTL ? 'rtl' : 'ltr', textAlign: isRTL ? 'right' : 'left', fontWeight: 600 }}>{item.title}</div>
-                <div className="myitems-card-meta" style={{ fontFamily: 'Heebo, Arial, sans-serif', fontSize: 13, color: '#607D8B', direction: isRTL ? 'rtl' : 'ltr', textAlign: isRTL ? 'right' : 'left', display: 'flex', alignItems: 'center', gap: 8 }}>
+                <div className="myitems-card-title" dir={isRTL ? 'rtl' : 'ltr'}>{item.title}</div>
+                <div className="myitems-card-meta" dir={isRTL ? 'rtl' : 'ltr'}>
                     {item.status && (
-                        <span style={{
-                            display: 'inline-flex',
-                            alignItems: 'center',
-                            background: item.status === 'active' ? '#C8E6C9' : item.status === 'expired' ? '#ECEFF1' : '#FFE0B2',
-                            color: item.status === 'active' ? '#388E3C' : item.status === 'expired' ? '#607D8B' : '#FFA000',
-                            borderRadius: 8,
-                            padding: '2px 8px',
-                            fontSize: 12,
-                            fontWeight: 500,
-                            marginRight: isRTL ? 0 : 8,
-                            marginLeft: isRTL ? 8 : 0,
-                        }}>
+                        <span >
                             ● {t(`common.${item.status}`)}
                         </span>
                     )}
                     {item.createdAt && <span>{format(new Date(item.createdAt), 'dd/MM/yyyy HH:mm')}</span>}</div>
-                <div className="myitems-card-actions" style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+                <div className="myitems-card-actions">
 
-                <button className="myitems-edit-btn" style={{ fontSize: 14, display: 'flex', alignItems: 'center', gap: 4 }} onClick={() => setEditTarget({ item, type: view === 'rentals' ? 'rental' : view === 'services' ? 'service' : view === 'rental_requests' ? 'rental_request' : 'service_request' })}>
+                <button className="myitems-edit-btn" onClick={() => setEditTarget({ item, type: view === 'rentals' ? 'rental' : view === 'services' ? 'service' : view === 'rental_requests' ? 'rental_request' : 'service_request' })}>
                     <span role="img" aria-label="edit">✏️</span>
                 </button>
-                <button className="myitems-delete-btn" style={{ fontSize: 14, display: 'flex', alignItems: 'center', gap: 4 }} onClick={() => setDeleteTarget({ item, type: view === 'rentals' ? 'rental' : view === 'services' ? 'service' : view === 'rental_requests' ? 'rental_request' : 'service_request' })}>
+                <button className="myitems-delete-btn" onClick={() => setDeleteTarget({ item, type: view === 'rentals' ? 'rental' : view === 'services' ? 'service' : view === 'rental_requests' ? 'rental_request' : 'service_request' })}>
                     <span role="img" aria-label="delete">🗑</span>
                 </button>
                 </div>
@@ -226,55 +214,21 @@ const MyModals = () => {
     return (
         <div className="my-items-container" dir={isRTL ? 'rtl' : 'ltr'}>
             <h2 className="main-title">{t('my_items.title')}</h2>
-            <div className="myitems-tabs" role="tablist" style={{ display: 'flex', justifyContent: 'center', gap: 12, marginBottom: 20, overflowX: 'auto', maxWidth: 480, marginLeft: 'auto', marginRight: 'auto' }}>
+            <div className="myitems-tabs" role="tablist">
                 {TAB_CATEGORIES.map(tab => (
                     <button
                         key={tab.key}
                         className={`myitems-tab${view === tab.key ? ' active' : ''}`}
                         onClick={() => setView(tab.key)}
-                        style={{
-                            fontFamily: 'Heebo, Arial, sans-serif',
-                            fontSize: 13,
-                            color: view === tab.key ? '#2E4057' : '#1C2526',
-                            fontWeight: view === tab.key ? 'bold' : 'normal',
-                            borderRadius: 10,
-                            direction: isRTL ? 'rtl' : 'ltr',
-                            background: 'none',
-                            border: 'none',
-                            padding: '8px 14px',
-                            cursor: 'pointer',
-                            position: 'relative',
-                            outline: 'none',
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            minWidth: 80,
-                            maxWidth: 120,
-                            whiteSpace: 'nowrap',
-                        }}
+                       
                         role="tab"
                         aria-selected={view === tab.key}
                     >
                         {tab.label}
-                        {view === tab.key && (
-                            <span style={{
-                                position: 'absolute',
-                                left: 0,
-                                right: 0,
-                                bottom: 0,
-                                height: 2,
-                                background: '#2E4057',
-                                borderRadius: 2,
-                                width: '80%',
-                                margin: '0 auto',
-                                display: 'block',
-                                content: '""',
-                            }} />
-                        )}
                     </button>
                 ))}
             </div>
-            <div className="myitems-list-scroll" style={{ maxWidth: 420, margin: '0 auto' }}>
+            <div className="myitems-list-scroll">
                 {(() => {
                     const items =
                         view === 'rentals' ? rentals :
@@ -305,23 +259,7 @@ const MyModals = () => {
             {(view === 'rentals' || view === 'services') && (
                 <button
                     className="myitems-add-btn"
-                    style={{
-                        marginTop: 2, // Changed from 24 to 10 to move the button upward                        padding: '12px 24px',
-                        background: '#087E8B',
-                        color: '#fff',
-                        border: 'none',
-                        borderRadius: 8,
-                        fontFamily: 'Heebo, Arial, sans-serif',
-                        fontSize: 16,
-                        cursor: 'pointer',
-                        width: '100%',
-                        maxWidth: 320,
-                        alignSelf: 'center',
-                        boxShadow: '0 2px 8px rgba(38, 166, 154, 0.08)'
-                    }}
                     onClick={() => navigate(view === 'rentals' ? '/offer-rental' : '/offer-service')}
-                    onMouseOver={e => e.currentTarget.style.background = '#009688'}
-                    onMouseOut={e => e.currentTarget.style.background = '#087E8B'}
                 >
                     {view === 'rentals' ? t('rentals.add_rental') : t('services.add_service')}
                 </button>
@@ -330,23 +268,7 @@ const MyModals = () => {
             {view === 'rental_requests' && (
                 <button
                     className="myitems-add-btn"
-                    style={{
-                        marginTop: 2, // Changed from 24 to 10 to move the button upward                        padding: '12px 24px',
-                        background: '#087E8B',
-                        color: '#fff',
-                        border: 'none',
-                        borderRadius: 8,
-                        fontFamily: 'Heebo, Arial, sans-serif',
-                        fontSize: 16,
-                        cursor: 'pointer',
-                        width: '100%',
-                        maxWidth: 320,
-                        alignSelf: 'center',
-                        boxShadow: '0 2px 8px rgba(38, 166, 154, 0.08)'
-                    }}
                     onClick={() => navigate('/request-rental')}
-                    onMouseOver={e => e.currentTarget.style.background = '#009688'}
-                    onMouseOut={e => e.currentTarget.style.background = '#087E8B'}
                 >
                     {t('rentals.request_rental')}
                 </button>
@@ -354,23 +276,7 @@ const MyModals = () => {
             {view === 'service_requests' && (
                 <button
                     className="myitems-add-btn"
-                    style={{
-                        marginTop: 0, // Changed from 24 to 10 to move the button upward                        padding: '12px 24px',
-                        background: '#087E8B',
-                        color: '#fff',
-                        border: 'none',
-                        borderRadius: 8,
-                        fontFamily: 'Heebo, Arial, sans-serif',
-                        fontSize: 16,
-                        cursor: 'pointer',
-                        width: '100%',
-                        maxWidth: 320,
-                        alignSelf: 'center',
-                        boxShadow: '0 2px 8px rgba(38, 166, 154, 0.08)'
-                    }}
                     onClick={() => navigate('/request-service')}
-                    onMouseOver={e => e.currentTarget.style.background = '#009688'}
-                    onMouseOut={e => e.currentTarget.style.background = '#087E8B'}
                 >
                     {t('services.request_service')}
                 </button>

--- a/frontend/src/styles/HomePage/TabBar.css
+++ b/frontend/src/styles/HomePage/TabBar.css
@@ -26,8 +26,7 @@
 }
 
 .tab-button.active {
-    color: inherit;
-    font-weight: 600;
+    color: #1C2526;
 }
 
 .tab-indicator {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -189,3 +189,28 @@ form a:hover {
   font-size: 14px;
   margin-top: -10px;
 }
+
+/* Reusable rounded action buttons */
+.toggle-view-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 9999px;
+  padding: 1rem 3rem;
+  font-size: 1rem;
+  border: 2px solid #2E4057;
+  background-color: #fff;
+  color: #2E4057;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  transition: all 0.2s ease;
+  cursor: pointer;
+}
+
+.toggle-view-btn:hover {
+  background-color: #F4F6F8;
+  color: #1C2526;
+  border-color: #1e8c7a;
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.12);
+  transform: translateY(-1px);
+}


### PR DESCRIPTION
## Summary
- remove status-based colors in HomePage TabBar
- keep indicator offset logic while dropping dynamic styling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6887a5b19f348331949aec3632480da1