### PR TITLE
Add address editing for items

### DIFF
--- a/backend/controllers/rentalController.js
+++ b/backend/controllers/rentalController.js
@@ -171,12 +171,12 @@ const getUserRentals = async (req, res) => {
 // Edit a rental
 const editRental = async (req, res) => {
     const { id } = req.params;
-    const { title, description, category, price, images, phone } = req.body;
+    const { title, description, category, price, images, phone, city, street, lat, lng } = req.body;
 
     try {
     const updated = await Rental.findByIdAndUpdate(
         id,
-        { title, description, category, price, images, phone },
+        { title, description, category, price, images, phone, city, street, lat, lng },
         { new: true }
     );
 

--- a/backend/controllers/serviceController.js
+++ b/backend/controllers/serviceController.js
@@ -135,12 +135,12 @@ const getUserServices = async (req, res) => {
 
 const editService = async (req, res) => {
     const { id } = req.params;
-    const { title, description, category, price, phone } = req.body;
+    const { title, description, category, price, phone, city, street, lat, lng } = req.body;
 
     try {
         const updated = await Service.findByIdAndUpdate(
             id,
-            { title, description, category, price, phone },
+            { title, description, category, price, phone, city, street, lat, lng },
             { new: true }
         );
 


### PR DESCRIPTION
## Summary
- include address fields in item edit modal
- geocode updated addresses before saving
- update rental and service controllers to accept updated address fields

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6887d4872e58833199771b6609bff430