### PR TITLE
feat: add givit icon to page wrapper

### DIFF
--- a/frontend/resources/givit.svg
+++ b/frontend/resources/givit.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#3b82f6"/>
+  <text x="16" y="21" font-size="16" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif">G</text>
+</svg>

--- a/frontend/src/components/PageWrapper.jsx
+++ b/frontend/src/components/PageWrapper.jsx
@@ -1,8 +1,14 @@
 import React from 'react';
+import givitIcon from '../../resources/givit.svg';
 
 const PageWrapper = ({ children }) => {
   return (
     <div className="relative w-full min-h-screen">
+      <img
+        src={givitIcon}
+        alt="givit"
+        className="absolute top-2 left-2 w-8 h-8"
+      />
       <div className="w-full">
         {children}
       </div>
@@ -10,4 +16,4 @@ const PageWrapper = ({ children }) => {
   );
 };
 
-export default PageWrapper; 
+export default PageWrapper;


### PR DESCRIPTION
## Summary
- add reusable `givit` icon asset
- render the icon in the upper-left corner for all pages

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688b91a2c1848331bc94849b38b98240