### PR TITLE
feat: allow address editing in listing

### DIFF
--- a/frontend/src/components/HomePage/geocode.js
+++ b/frontend/src/components/HomePage/geocode.js
@@ -1,21 +1,22 @@
 export const geocodeAddress = async (street, city) => {
-    const address = encodeURIComponent(`${street}, ${city}`);
+    const query = [street, city].filter(Boolean).join(', ');
+    const address = encodeURIComponent(query);
     const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
 
     const response = await fetch(
-    `https://maps.googleapis.com/maps/api/geocode/json?address=${address}&key=${apiKey}&region=il&language=he`
+        `https://maps.googleapis.com/maps/api/geocode/json?address=${address}&key=${apiKey}&region=il&language=he`
     );
 
     const data = await response.json();
 
     if (data.status === "OK") {
-    const location = data.results[0].geometry.location;
-    return {
-        lat: location.lat,
-        lng: location.lng,
-    };
+        const location = data.results[0].geometry.location;
+        return {
+            lat: location.lat,
+            lng: location.lng,
+        };
     } else {
-    console.error("Geocoding error:", data.status, street, city);
-    return null;
+        console.error('Geocoding error:', data.status, street, city);
+        return null;
     }
 };

--- a/frontend/src/components/MyItems/EditModal.jsx
+++ b/frontend/src/components/MyItems/EditModal.jsx
@@ -11,6 +11,7 @@ const EditModal = ({ item, type, onSave, onCancel }) => {
         ...item,
         city: item.city || '',
         street: item.street || '',
+        location: item.location || '',
     });
 
     const handleChange = (e) => {
@@ -23,6 +24,11 @@ const EditModal = ({ item, type, onSave, onCancel }) => {
         try {
             if (form.street && form.city) {
                 const coords = await geocodeAddress(form.street, form.city);
+                if (coords) {
+                    updatedForm = { ...updatedForm, ...coords };
+                }
+            } else if (form.location) {
+                const coords = await geocodeAddress(form.location);
                 if (coords) {
                     updatedForm = { ...updatedForm, ...coords };
                 }
@@ -63,6 +69,9 @@ const EditModal = ({ item, type, onSave, onCancel }) => {
 
                 <label htmlFor="phone">{t('common.phone')}</label>
                 <input name="phone" value={form.phone} onChange={handleChange} />
+
+                <label htmlFor="location">{t('common.location')}</label>
+                <input name="location" value={form.location} onChange={handleChange} />
 
                 <label htmlFor="city">{t('common.city')}</label>
                 <input name="city" value={form.city} onChange={handleChange} />

--- a/frontend/src/components/MyItems/ModalCard.jsx
+++ b/frontend/src/components/MyItems/ModalCard.jsx
@@ -144,8 +144,15 @@ const ModalCard = ({ item, onDeleteSuccess, onEditSuccess, type = 'rental' }) =>
                         <div><strong>{t('common.category')}:</strong> {item.category}</div>
                         <div><strong>{t('common.phone')}:</strong> {item.phone}</div>
                         <div><strong>{t('common.price')}:</strong> {item.price}₪ / {translatePricePeriod(item.pricePeriod)}</div>
-                        <div><strong>{t('common.city')}:</strong> {item.city}</div>
-                        <div><strong>{t('common.street')}:</strong> {item.street}</div>
+                        {item.location && (
+                            <div><strong>{t('common.location')}:</strong> {item.location}</div>
+                        )}
+                        {item.city && (
+                            <div><strong>{t('common.city')}:</strong> {item.city}</div>
+                        )}
+                        {item.street && (
+                            <div><strong>{t('common.street')}:</strong> {item.street}</div>
+                        )}
                     </div>
                 </div>
             )}

--- a/frontend/src/en.json
+++ b/frontend/src/en.json
@@ -35,6 +35,7 @@
     "category": "Category",
     "phone": "Phone",
     "price": "Price",
+    "location": "Location",
     "city": "City",
     "street": "Street",
     "title": "Title",

--- a/frontend/src/he.json
+++ b/frontend/src/he.json
@@ -33,6 +33,7 @@
         "category": "קטגוריה",
         "phone": "טלפון",
         "price": "מחיר",
+        "location": "מיקום",
         "city": "עיר",
         "street": "רחוב",
         "title": "כותרת",


### PR DESCRIPTION
## Summary
- allow address changes when editing listings, geocoding location if available
- display listing address when viewing item details
- add translation entries for location in English and Hebrew

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688b96a070048331b414fe83cb7c2d4c