### PR TITLE
feat: allow rating rentals and services

### DIFF
--- a/backend/controllers/rentalController.js
+++ b/backend/controllers/rentalController.js
@@ -72,7 +72,7 @@ const getRentals = async (req, res) => {
         let query = {};
         let rentals = [];
         // Only select fields needed for the map/popup
-        let selectFields = 'firstName lastName email title description category price pricePeriod images phone status city street ownerId lat lng';
+        let selectFields = 'firstName lastName email title description category price pricePeriod images phone status city street ownerId lat lng rating ratingCount';
         // Bounding box filter (fast, uses index)
         if (
             minLat !== undefined && maxLat !== undefined &&
@@ -202,6 +202,22 @@ const deleteRental = async (req, res) => {
     }
 };
 
+const rateRental = async (req, res) => {
+    const { id } = req.params;
+    const { rating } = req.body;
+    try {
+        const rental = await Rental.findById(id);
+        if (!rental) return res.status(404).json({ error: 'Rental not found' });
+        const value = Math.max(1, Math.min(5, parseFloat(rating)));
+        rental.rating = ((rental.rating || 0) * (rental.ratingCount || 0) + value) / ((rental.ratingCount || 0) + 1);
+        rental.ratingCount = (rental.ratingCount || 0) + 1;
+        await rental.save();
+        res.status(200).json({ rating: rental.rating, ratingCount: rental.ratingCount });
+    } catch (err) {
+        res.status(500).json({ error: 'Failed to rate rental' });
+    }
+};
+
 const searchRentals = async (req, res) => {
     try {
     const { query } = req.query;
@@ -261,6 +277,7 @@ module.exports = {
     getUserRentals,
     editRental,
     deleteRental,
+    rateRental,
     searchRentals,
     filterRentals,
 };

--- a/backend/models/Rental.js
+++ b/backend/models/Rental.js
@@ -19,6 +19,8 @@ const rentalSchema = new mongoose.Schema({
     lng: { type: Number },
     ownerId: { type: String, required: true },
     firebaseUid: { type: String, required: true },
+    rating: { type: Number, default: 0 },
+    ratingCount: { type: Number, default: 0 },
 }, { timestamps: true });
 
 // Add compound index for spatial queries

--- a/backend/models/Service.js
+++ b/backend/models/Service.js
@@ -19,6 +19,8 @@ const serviceSchema = new mongoose.Schema({
     street: { type: String },
     lat: { type: Number },
     lng: { type: Number },
+    rating: { type: Number, default: 0 },
+    ratingCount: { type: Number, default: 0 },
     createdAt: { type: Date, default: Date.now },
 });
 

--- a/backend/routes/rentalRoutes.js
+++ b/backend/routes/rentalRoutes.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { uploadNewRental, getRentals, getUserRentals, editRental, deleteRental, searchRentals, filterRentals } = require('../controllers/rentalController.js');
+const { uploadNewRental, getRentals, getUserRentals, editRental, deleteRental, searchRentals, filterRentals, rateRental } = require('../controllers/rentalController.js');
 const { protect } = require('../middleware/authMiddleware.js');
 const upload = require('../middleware/upload');
 
@@ -14,6 +14,7 @@ router.get('/', getRentals);
 router.get('/user', protect, getUserRentals);
 router.put('/:id', protect, editRental);
 router.delete('/:id', protect, deleteRental);
+router.post('/:id/rate', protect, rateRental);
 router.get("/search", searchRentals);
 router.get('/filter', filterRentals);
 

--- a/backend/routes/serviceRoutes.js
+++ b/backend/routes/serviceRoutes.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const router = express.Router();
-const { uploadNewService, getServices, getUserServices, editService, deleteService, searchServices, filterServices } = require('../controllers/serviceController');
+const { uploadNewService, getServices, getUserServices, editService, deleteService, searchServices, filterServices, rateService } = require('../controllers/serviceController');
 const { protect } = require('../middleware/authMiddleware');
 const upload = require('../middleware/upload.js');
 
@@ -11,6 +11,7 @@ router.get('/', getServices); // GET /api/services
 router.get('/user', protect, getUserServices); // GET /api/services/user
 router.put('/:id', protect, editService); // PUT /api/services/:id
 router.delete('/:id', protect, deleteService); // DELETE /api/services/:id
+router.post('/:id/rate', protect, rateService);
 router.get("/search", searchServices);
 router.get('/filter', filterServices); // GET /api/services/filter?category=Electronics&maxPrice=150
 

--- a/frontend/src/components/HomePage/GenericMapPage.jsx
+++ b/frontend/src/components/HomePage/GenericMapPage.jsx
@@ -1008,6 +1008,7 @@ const GenericMapPage = ({ apiUrl }) => {
                             locations={locations}
                             mapHeight={"100%"}
                             onBoundsChanged={setMapBounds}
+                            contentType={contentType}
                         />
                         {/* Overlay controls and labels at the top of the map */}
                         <div style={{
@@ -1086,7 +1087,7 @@ const GenericMapPage = ({ apiUrl }) => {
                             overflowY: 'auto',
                             position: 'relative'
                         }}>
-                            <ListView rentals={allItems} />
+                            <ListView rentals={allItems} contentType={contentType} />
                         </div>
                     </div>
                 </div>

--- a/frontend/src/components/HomePage/ListView.jsx
+++ b/frontend/src/components/HomePage/ListView.jsx
@@ -4,7 +4,7 @@ import Popup from "../Shared/Popup"; // Import the correct Popup component
 import '../../styles/HomePage/ListView.css';
 import { usePricePeriodTranslation } from '../../utils/pricePeriodTranslator';
 
-const ListView = ({ rentals }) => {
+const ListView = ({ rentals, contentType }) => {
   // Rename state for clarity (optional but good practice)
   const [selectedItem, setSelectedItem] = useState(null);
   const [loadedImages, setLoadedImages] = useState({});
@@ -53,6 +53,7 @@ const ListView = ({ rentals }) => {
               <p className="rental-info">Category: {rental.category}</p>
               <p className="rental-info">Price: {rental.price} {translatePricePeriod(rental.pricePeriod)}</p>
               <p className="rental-info">Location: {rental.city}</p>
+              <p className="rental-info">Rating: {rental.rating ? rental.rating.toFixed(1) : 'N/A'}</p>
             </div>
           </div>
         ))}
@@ -60,7 +61,7 @@ const ListView = ({ rentals }) => {
 
       {/* Use the Popup component */}
       {selectedItem && (
-        <Popup item={selectedItem} onClose={handleClosePopup} />
+        <Popup item={selectedItem} onClose={handleClosePopup} contentType={contentType} />
       )}
     </div>
   );

--- a/frontend/src/components/HomePage/MapView.jsx
+++ b/frontend/src/components/HomePage/MapView.jsx
@@ -77,7 +77,7 @@ const defaultCenter = {
 
 
 
-const MapView = ({ locations, mapHeight, onBoundsChanged, children }) => {
+const MapView = ({ locations, mapHeight, onBoundsChanged, children, contentType }) => {
     const [selectedItem, setSelectedItem] = useState(null);
     const [userLocation, setUserLocation] = useState(null);
     const mapRef = useRef(null);
@@ -371,7 +371,7 @@ const MapView = ({ locations, mapHeight, onBoundsChanged, children }) => {
                 </button>
             )}
 
-            <Popup item={selectedItem} onClose={handlePopupClose} />
+            <Popup item={selectedItem} onClose={handlePopupClose} contentType={contentType} />
         </div>
     );
 };


### PR DESCRIPTION
## Summary
- add rating and ratingCount fields to rental and service models
- expose POST endpoints to rate rentals and services
- surface ratings and allow star-based rating in listing popup

## Testing
- `cd backend && npm test` (fails: Missing script "test")
- `cd frontend && npm test` (fails: Missing script "test")
- `cd frontend && npm run lint` (fails: React Hook "useAuthContext" is called conditionally, no-unused-vars)


------
https://chatgpt.com/codex/tasks/task_e_6898aff2de548331a5385e5e60902793