### PR TITLE
feat: make services page the default landing

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -46,8 +46,9 @@ function App() {
         <div className="app-container">
           <Routes>
             <Route element={<Layout />}>
-                <Route path="/" element={<RentalsMapPage />} />
+                <Route path="/" element={<ServicesMapPage />} />
                 <Route path="/services" element={<ServicesMapPage />} />
+                <Route path="/rentals" element={<RentalsMapPage />} />
                 <Route path="/account" element={user ? <Navigate to="/dashboard" /> : <Account />} />
                 <Route path="/dashboard" element={<Dashboard />} />
                 <Route path="/edit-profile" element={<EditProfile />} />

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -17,8 +17,8 @@ function Navbar() {
   const { t } = useTranslation();
 
   const tabs = [
-    { icon: <FiPackage  />, path: '/', label: t('navigation.home') },
-    { icon: <RiUserSettingsLine  />, path: '/services', label: t('navigation.services') },
+    { icon: <RiUserSettingsLine />, path: '/', label: t('navigation.services') },
+    { icon: <FiPackage />, path: '/rentals', label: t('navigation.rentals') },
     //{ icon: <AiOutlineMessage />, path: '/messages', label: t('navigation.messages') },
     { icon: <BsViewList />, path: '/my-items', label: t('navigation.my_items') },
     { icon: <VscAccount />, path: user ? '/dashboard' : '/account', label: t('navigation.account') },


### PR DESCRIPTION
## Summary
- Load the services map at the root route and expose rentals at `/rentals`
- Update navigation bar so Services is the first tab and Rentals is available separately

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689c5303dd8483318d6c3f99fddcd90e