### PR TITLE
fix: prepare Android map support

### DIFF
--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
     implementation project(':capacitor-cordova-android-plugins')
+    implementation "com.google.android.gms:play-services-maps:18.2.0"
 }
 
 apply from: 'capacitor.build.gradle'

--- a/frontend/android/app/src/main/AndroidManifest.xml
+++ b/frontend/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
         android:allowBackup="true"
@@ -11,6 +13,10 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true">
+
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="@string/google_maps_key" />
 
         <activity
             android:name=".MainActivity"
@@ -49,7 +55,7 @@
         </activity>
 
         <!-- 📂 FileProvider -->
-        <providerL
+        <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"
             android:exported="false"
@@ -57,7 +63,7 @@
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />
-        </providerL>
+        </provider>
 
     </application>
 </manifest>

--- a/frontend/android/app/src/main/res/values/strings.xml
+++ b/frontend/android/app/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="title_activity_main">Givit</string>
     <string name="package_name">com.orirot.givit</string>
     <string name="custom_url_scheme">com.orirot.givit</string>
+    <string name="google_maps_key">YOUR_API_KEY_HERE</string>
 </resources>


### PR DESCRIPTION
## Summary
- allow location and supply Google Maps API key in manifest
- add Google Play Services Maps dependency
- fix FileProvider tag in Android manifest

## Testing
- `npm run lint`
- `bash gradlew assembleDebug` *(fails: Could not read script '.../cordova.variables.gradle' as it does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689cafe897888331a26dcb416da135d4