### PR TITLE
Fix map and list not loading by adding API URL fallbacks

### DIFF
--- a/frontend/src/components/HomePage/GenericMapPage.jsx
+++ b/frontend/src/components/HomePage/GenericMapPage.jsx
@@ -533,8 +533,11 @@ const GenericMapPage = ({ apiUrl }) => {
         setSelectedCategory(null);
     }, [contentType]);
 
-    // Memoized base URL
-    const baseUrl = useMemo(() => import.meta.env.VITE_API_URL, []);
+    // Memoized base URL with fallback to deployed backend
+    const baseUrl = useMemo(
+        () => import.meta.env.VITE_API_URL || 'https://giveit-backend.onrender.com',
+        []
+    );
 
     // Define tabs based on contentType and language
     const tabs = useMemo(() => {

--- a/frontend/src/components/HomePage/ListView.jsx
+++ b/frontend/src/components/HomePage/ListView.jsx
@@ -38,7 +38,7 @@ const ListView = ({ rentals, contentType }) => {
             <div className="rental-image-container">
               {rental.images && rental.images[0] ? (
                 <img
-                  src={`${import.meta.env.VITE_API_URL}${rental.images[0]}`} // Use the first image from the array, prepended with backend URL
+                  src={`${import.meta.env.VITE_API_URL || 'https://giveit-backend.onrender.com'}${rental.images[0]}`} // Use the first image from the array, prepended with backend URL
                   alt={rental.title}
                   className={`rental-image ${loadedImages[rental._id] ? 'loaded' : 'loading'}`}
                   onLoad={() => handleImageLoad(rental._id)}

--- a/frontend/src/components/HomePage/RentalsMapPage.jsx
+++ b/frontend/src/components/HomePage/RentalsMapPage.jsx
@@ -6,7 +6,7 @@ const RentalsMapPage = () => {
     const { t } = useTranslation();  // t is the function to get translated strings
 return (
     <GenericMapPage
-    apiUrl={`${import.meta.env.VITE_API_URL}/api/rentals`}
+    apiUrl={`${import.meta.env.VITE_API_URL || 'https://giveit-backend.onrender.com'}/api/rentals`}
     title={t("Explore offers")}
     />
 );

--- a/frontend/src/components/HomePage/RentalsPage.jsx
+++ b/frontend/src/components/HomePage/RentalsPage.jsx
@@ -6,7 +6,7 @@ const RentalsPage = () => {
     const { t } = useTranslation();
     return (
         <GenericMapPage
-            apiUrl={`${import.meta.env.VITE_API_URL}/api/rentals`}
+            apiUrl={`${import.meta.env.VITE_API_URL || 'https://giveit-backend.onrender.com'}/api/rentals`}
             title={t("Rentals")}
         />
     );

--- a/frontend/src/components/HomePage/ServicesMapPage.jsx
+++ b/frontend/src/components/HomePage/ServicesMapPage.jsx
@@ -6,7 +6,7 @@ const ServicesMapPage = () => {
     const { t, i18n } = useTranslation();
     return (
         <GenericMapPage
-            apiUrl={`${import.meta.env.VITE_API_URL}/api/services`}
+            apiUrl={`${import.meta.env.VITE_API_URL || 'https://giveit-backend.onrender.com'}/api/services`}
             title={i18n.language === 'he' ? t('Explore Services') : 'Explore Services'}
         />
     );

--- a/frontend/src/components/HomePage/ServicesPage.jsx
+++ b/frontend/src/components/HomePage/ServicesPage.jsx
@@ -6,7 +6,7 @@ const ServicesPage = () => {
     const { t, i18n } = useTranslation();
     return (
         <GenericMapPage
-            apiUrl={`${import.meta.env.VITE_API_URL}/api/services`}
+            apiUrl={`${import.meta.env.VITE_API_URL || 'https://giveit-backend.onrender.com'}/api/services`}
             title={i18n.language === 'he' ? t('Services') : 'Services'}
         />
     );


### PR DESCRIPTION
## Summary
- Provide default backend URL in GenericMapPage when `VITE_API_URL` is missing
- Use same fallback in map page components and ListView image URLs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cd7956cac8331911596b200ae703e