### PR TITLE
feat: add sliding header search bar

### DIFF
--- a/frontend/src/components/HomePage/GenericMapPage.jsx
+++ b/frontend/src/components/HomePage/GenericMapPage.jsx
@@ -244,24 +244,17 @@ const Controls = React.memo(({
 }) => {
     const [showSearchBar, setShowSearchBar] = useState(false);
 
-    const toggleSearchBar = () => {
-        setShowSearchBar(!showSearchBar);
-        if (showSearchBar) {
-            // Clear search when hiding
-            setSearchQuery("");
-            onClearFilters();
-        }
-    };
+    const openSearchBar = () => setShowSearchBar(true);
 
-    const handleBackButton = () => {
-        // Clear search and hide search bar
+    const handleCloseSearch = () => {
+        setShowSearchBar(false);
         setSearchQuery("");
         onClearFilters();
-        setShowSearchBar(false);
     };
 
     return (
         <div className="controls-container" style={{
+            position: 'relative',
             padding: `${DESIGN_TOKENS.spacing.md} ${DESIGN_TOKENS.spacing.sm} 0px`,
             display: 'flex',
             flexDirection: 'column',
@@ -269,63 +262,16 @@ const Controls = React.memo(({
             alignItems: 'flex-start',
             fontFamily: DESIGN_TOKENS.typography.fontFamily.primary
         }}>
-            {showSearchBar ? (
-                <div style={{
-                    position: 'relative',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    gap: '8px',
-                    height: '48px'
-                }}>
+            <div className="search-toggle-container" style={{
+                display: 'flex',
+                justifyContent: 'flex-end',
+                alignItems: 'center',
+                gap: '12px',
+                padding: '0 8px'
+            }}>
+                {!showSearchBar && (
                     <button
-                        onClick={handleBackButton}
-                        className="back-button"
-                        style={{
-                            background: 'transparent',
-                            color: '#000000',
-                            border: 'none',
-                            borderRadius: '50%',
-                            width: '32px',
-                            height: '32px',
-                            cursor: 'pointer',
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            flexShrink: 0
-                        }}
-                        onMouseOver={e => e.currentTarget.style.color = '#000000'}
-                        onMouseOut={e => e.currentTarget.style.color = '#000000'}
-                        aria-label="Back"
-                    >
-                        <svg 
-                            width="16" 
-                            height="16" 
-                            viewBox="0 0 24 24" 
-                            fill="none" 
-                            stroke="currentColor" 
-                            strokeWidth="2"
-                        >
-                            <polyline points="15,18 9,12 15,6"></polyline>
-                        </svg>
-                    </button>
-                    <SearchBar
-                        searchQuery={searchQuery}
-                        setSearchQuery={setSearchQuery}
-                        onSearch={onSearch}
-                        onClearFilters={onClearFilters}
-                    />
-                </div>
-            ) : (
-                <div className="search-toggle-container" style={{
-                    display: 'flex',
-                    justifyContent: 'flex-end',
-                    alignItems: 'center',
-                    gap: '12px',
-                    padding: '0 8px'
-                }}>
-                    <button
-                        onClick={toggleSearchBar}
+                        onClick={openSearchBar}
                         className="search-button"
                         style={{
                             background: 'transparent',
@@ -343,81 +289,89 @@ const Controls = React.memo(({
                         onMouseOut={e => e.currentTarget.style.color = '#000000'}
                         aria-label="Search"
                     >
-                        <svg 
-                            width="20" 
-                            height="20" 
-                            viewBox="0 0 24 24" 
-                            fill="none" 
-                            stroke="currentColor" 
+                        <svg
+                            width="20"
+                            height="20"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
                             strokeWidth="2"
                         >
                             <circle cx="11" cy="11" r="8"></circle>
                             <path d="m21 21-4.35-4.35"></path>
                         </svg>
                     </button>
-                    <button
-                        onClick={onAddListing}
-                        className="add-listing-button"
-                        style={{
-                            background: 'transparent',
-                            color: '#000000',
-                            border: 'none',
-                            borderRadius: '50%',
-                            width: '40px',
-                            height: '40px',
-                            cursor: 'pointer',
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center'
-                        }}
-                        onMouseOver={e => e.currentTarget.style.color = '#333333'}
-                        onMouseOut={e => e.currentTarget.style.color = '#000000'}
-                        aria-label="Add Listing"
+                )}
+                <button
+                    onClick={onAddListing}
+                    className="add-listing-button"
+                    style={{
+                        background: 'transparent',
+                        color: '#000000',
+                        border: 'none',
+                        borderRadius: '50%',
+                        width: '40px',
+                        height: '40px',
+                        cursor: 'pointer',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center'
+                    }}
+                    onMouseOver={e => e.currentTarget.style.color = '#333333'}
+                    onMouseOut={e => e.currentTarget.style.color = '#000000'}
+                    aria-label="Add Listing"
+                >
+                    <svg
+                        width="20"
+                        height="20"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
                     >
-                        <svg 
-                            width="20" 
-                            height="20" 
-                            viewBox="0 0 24 24" 
-                            fill="none" 
-                            stroke="currentColor" 
-                            strokeWidth="2"
-                        >
-                            <line x1="12" y1="5" x2="12" y2="19"></line>
-                            <line x1="5" y1="12" x2="19" y2="12"></line>
-                        </svg>
-                    </button>
-                    <button
-                        onClick={onMessages}
-                        className="messages-button"
-                        style={{
-                            background: 'transparent',
-                            color: '#000000',
-                            border: 'none',
-                            borderRadius: '50%',
-                            width: '40px',
-                            height: '40px',
-                            cursor: 'pointer',
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center'
-                        }}
-                        onMouseOver={e => e.currentTarget.style.color = '#333333'}
-                        onMouseOut={e => e.currentTarget.style.color = '#000000'}
-                        aria-label="Messages"
+                        <line x1="12" y1="5" x2="12" y2="19"></line>
+                        <line x1="5" y1="12" x2="19" y2="12"></line>
+                    </svg>
+                </button>
+                <button
+                    onClick={onMessages}
+                    className="messages-button"
+                    style={{
+                        background: 'transparent',
+                        color: '#000000',
+                        border: 'none',
+                        borderRadius: '50%',
+                        width: '40px',
+                        height: '40px',
+                        cursor: 'pointer',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center'
+                    }}
+                    onMouseOver={e => e.currentTarget.style.color = '#333333'}
+                    onMouseOut={e => e.currentTarget.style.color = '#000000'}
+                    aria-label="Messages"
+                >
+                    <svg
+                        width="20"
+                        height="20"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
                     >
-                        <svg 
-                            width="20" 
-                            height="20" 
-                            viewBox="0 0 24 24" 
-                            fill="none" 
-                            stroke="currentColor" 
-                            strokeWidth="2"
-                        >
-                            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
-                        </svg>
-                    </button>
-                </div>
-            )}
+                        <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+                    </svg>
+                </button>
+            </div>
+            <div className={`search-bar-wrapper ${showSearchBar ? 'open' : ''}`}>
+                <SearchBar
+                    searchQuery={searchQuery}
+                    setSearchQuery={setSearchQuery}
+                    onSearch={onSearch}
+                    onClose={handleCloseSearch}
+                />
+            </div>
             <TabBar
                 activeTab={contentType}
                 onTabChange={setContentType}

--- a/frontend/src/components/HomePage/GenericMapPage_backup.jsx
+++ b/frontend/src/components/HomePage/GenericMapPage_backup.jsx
@@ -313,7 +313,7 @@ const Controls = React.memo(({
                         searchQuery={searchQuery}
                         setSearchQuery={setSearchQuery}
                         onSearch={onSearch}
-                        onClearFilters={onClearFilters}
+                        onClose={toggleSearchBar}
                     />
                 </div>
             ) : (

--- a/frontend/src/components/HomePage/SearchBar.jsx
+++ b/frontend/src/components/HomePage/SearchBar.jsx
@@ -1,113 +1,44 @@
-import React, { useState } from "react";
+import React from "react";
 import { CiSearch } from "react-icons/ci";
+import { IoClose } from "react-icons/io5";
 import { useTranslation } from 'react-i18next';
 
-const SearchBar = ({ searchQuery, setSearchQuery, onSearch, onClearFilters }) => {
-  const [isSearched, setIsSearched] = useState(false);
+const SearchBar = ({ searchQuery, setSearchQuery, onSearch, onClose }) => {
   const { t, i18n } = useTranslation();
   const isRTL = i18n.language === 'he';
 
-  const handleSearch = () => {
-    if (typeof onSearch === 'function') {
-      onSearch();
-    }
-    if (searchQuery.trim() !== "") {
-      setIsSearched(true);
-    } else {
-      setIsSearched(false);
-    }
-  };
-
-  const handleClearSearch = () => {
-    setSearchQuery("");
-    setIsSearched(false);
-    if (typeof onSearch === 'function') {
-      onSearch();
-    }
-    if (typeof onClearFilters === 'function') {
-      onClearFilters();
-    }
-  };
-
   const handleKeyPress = (e) => {
-    if (e.key === "Enter") {
-      handleSearch();
-    }
-  };
-
-  const handleInputChange = (e) => {
-    setSearchQuery(e.target.value);
-    if (e.target.value.trim() === "") {
-      setIsSearched(false);
+    if (e.key === "Enter" && typeof onSearch === 'function') {
+      onSearch();
     }
   };
 
   return (
     <div className="flex justify-center">
-      <div className="relative w-[100%] max-w-md flex items-center gap-1 mx-auto" dir={isRTL ? 'rtl' : 'ltr'}>
-        <div className="relative flex-1">
-          <input
-            type="text"
-            placeholder={t('rentals.search_placeholder')}
-            value={searchQuery}
-            onChange={handleInputChange}
-            onKeyPress={handleKeyPress}
-            className={`w-full px-10 py-3 border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent text-base bg-white transition-all duration-200 ${isRTL ? 'text-right pr-12 pl-5' : 'text-left pl-12 pr-5'}`}
-            style={{
-              borderRadius: '25px',
-              fontSize: '16px',
-              height: '48px',
-              boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
-            }}
-          />
-          
-          {/* Search icon inside input */}
-
-        </div>
-
-        {isSearched ? (
-          <button
-            onClick={handleClearSearch}
-            className="search-filter-style red"
-            style={{
-              borderRadius: '20px',
-              padding: '8px 16px',
-              background: '#f44336',
-              color: 'white',
-              border: 'none',
-              fontSize: '14px',
-              fontWeight: '500',
-              cursor: 'pointer',
-              transition: 'all 0.2s ease',
-              minWidth: '60px',
-              height: '36px'
-            }}
-          >
-            {t('common.clear')}
-          </button>
-        ) : (
-          <button
-            onClick={handleSearch}
-            className="search-filter-style gray flex items-center justify-center"
-            style={{
-              borderRadius: '50%',
-              padding: '12px',
-              background: '#087E8B',
-              color: 'white',
-              border: 'none',
-              cursor: 'pointer',
-              transition: 'all 0.2s ease',
-              width: '48px',
-              height: '48px',
-              boxShadow: '0 2px 8px rgba(8, 126, 139, 0.2)'
-            }}
-            aria-label="Search"
-            onMouseOver={e => e.currentTarget.style.background = '#009688'}
-            onMouseOut={e => e.currentTarget.style.background = '#087E8B'}
-          >
-            <CiSearch className="text-xl" />
-          </button>
-        )}
+      <div className="relative w-[100%] max-w-md mx-auto" dir={isRTL ? 'rtl' : 'ltr'}>
+        <CiSearch className={`absolute top-1/2 -translate-y-1/2 text-gray-500 ${isRTL ? 'right-3' : 'left-3'}`} />
+        <input
+          type="text"
+          placeholder={t('rentals.search_placeholder')}
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          onKeyPress={handleKeyPress}
+          className={`w-full py-3 border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent text-base bg-white transition-all duration-200 ${isRTL ? 'text-right pr-12 pl-10' : 'text-left pl-10 pr-12'}`}
+          style={{
+            borderRadius: '25px',
+            fontSize: '16px',
+            height: '48px',
+            boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+          }}
+        />
+        <button
+          onClick={onClose}
+          aria-label="Close search"
+          title="Close search"
+          className={`absolute top-1/2 -translate-y-1/2 bg-gray-200 hover:bg-gray-300 text-gray-600 rounded-full p-1 transition-colors ${isRTL ? 'left-3' : 'right-3'}`}
+        >
+          <IoClose />
+        </button>
       </div>
     </div>
   );

--- a/frontend/src/styles/HomePage/GenericMapPage.css
+++ b/frontend/src/styles/HomePage/GenericMapPage.css
@@ -89,6 +89,25 @@ body, .main-bg-gradient {
     align-items: center;
     box-shadow: 0 2px 6px rgba(0,0,0,0.05);
   }
+
+.search-bar-wrapper {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    width: 100%;
+    transform: translateY(-100%);
+    transition: transform 0.3s ease-in-out;
+    padding: 0.5rem 1rem;
+    background: white;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    border-bottom-left-radius: 0.5rem;
+    border-bottom-right-radius: 0.5rem;
+    z-index: 50;
+}
+
+.search-bar-wrapper.open {
+    transform: translateY(0);
+}
   
 .toggle-view-btn {
     display: inline-flex;


### PR DESCRIPTION
## Summary
- animate search bar to slide below header and avoid logo overlap
- include accessible close button inside search bar
- style search bar with padding, rounded corners and shadow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689de35273648331b4a6fad2db180018