### PR TITLE
feat: toggle listing availability

### DIFF
--- a/frontend/src/styles/components/MyItems.css
+++ b/frontend/src/styles/components/MyItems.css
@@ -210,6 +210,28 @@
   margin-top: 6px;
 }
 
+.myitems-status-btn {
+  background: transparent;
+  color: var(--primary-color);
+  border: 2.5px solid var(--primary-color);
+  border-radius: 24px;
+  padding: 6px 20px;
+  font-family: var(--font-primary);
+  font-size: 14px;
+  font-weight: 400;
+  cursor: pointer;
+  transition: background 0.25s ease, color 0.25s ease, box-shadow 0.25s ease;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.myitems-status-btn:hover {
+  background: var(--primary-color);
+  color: #fff;
+  box-shadow: 0 8px 20px rgba(38, 166, 154, 0.6);
+}
+
 /* Edit button */
 .myitems-edit-btn {
   background: var(--primary-color);


### PR DESCRIPTION
## Summary
- allow users to mark their services and rentals as available or not available
- filter rental and service queries so only available listings appear publicly
- add styling for new availability toggle

## Testing
- `npm test` (frontend) *(fails: Missing script)*
- `npm run lint`
- `npm test` (backend) *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689f25bbc3948331ba6fb653a605cf99