### PR TITLE
feat: add basic login flow to native app

### DIFF
--- a/frontend-native/App.js
+++ b/frontend-native/App.js
@@ -9,6 +9,7 @@ import Dashboard from './src/screens/Dashboard';
 import EditProfile from './src/screens/EditProfile';
 import Home from './src/screens/Home';
 import Messages from './src/screens/Messages';
+import Login from './src/screens/Login';
 
 const Stack = createNativeStackNavigator();
 
@@ -22,6 +23,7 @@ export default function App() {
           <Stack.Screen name="Rentals" component={RentalsMapPage} />
           <Stack.Screen name="Services" component={ServicesMapPage} />
           <Stack.Screen name="Account" component={Account} />
+          <Stack.Screen name="Login" component={Login} />
           <Stack.Screen name="Dashboard" component={Dashboard} />
           <Stack.Screen name="EditProfile" component={EditProfile} />
         </Stack.Navigator>

--- a/frontend-native/README.md
+++ b/frontend-native/README.md
@@ -3,4 +3,6 @@
 This directory contains a React Native port of the GiveIt frontend.
 It uses Expo and React Navigation. A basic **Home** screen fetches and displays
 rentable items and placeholder screens are provided for other sections of the
-app. Further work is needed to reach feature parity with the web frontend.
+app. A basic login screen hooks into a simple authentication context and the
+Account screen displays the logged-in user's email with a logout option. Further
+work is needed to reach feature parity with the web frontend.

--- a/frontend-native/src/screens/Account.js
+++ b/frontend-native/src/screens/Account.js
@@ -1,14 +1,36 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, Button } from 'react-native';
+import { useAuthContext } from '../context/AuthContext';
 
-export default function Account() {
+export default function Account({ navigation }) {
+  const { user, logout } = useAuthContext();
+
+  if (!user) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.title}>Please log in to view your account</Text>
+        <Button title="Go to Login" onPress={() => navigation.navigate('Login')} />
+      </View>
+    );
+  }
+
   return (
     <View style={styles.container}>
-      <Text>Account - TODO: implement</Text>
+      <Text style={styles.title}>Logged in as {user.email}</Text>
+      <Button title="Logout" onPress={logout} />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16
+  },
+  title: {
+    fontSize: 16,
+    marginBottom: 16
+  }
 });

--- a/frontend-native/src/screens/Login.js
+++ b/frontend-native/src/screens/Login.js
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { useAuthContext } from '../context/AuthContext';
+
+export default function Login({ navigation }) {
+  const { login } = useAuthContext();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleLogin = async () => {
+    await login(email, password);
+    navigation.replace('Account');
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.label}>Email</Text>
+      <TextInput
+        value={email}
+        onChangeText={setEmail}
+        style={styles.input}
+        autoCapitalize="none"
+        keyboardType="email-address"
+      />
+      <Text style={styles.label}>Password</Text>
+      <TextInput
+        value={password}
+        onChangeText={setPassword}
+        style={styles.input}
+        secureTextEntry
+      />
+      <Button title="Login" onPress={handleLogin} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    justifyContent: 'center'
+  },
+  label: {
+    marginBottom: 8
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 16,
+    borderRadius: 4
+  }
+});
+


### PR DESCRIPTION
## Summary
- add simple login screen using auth context
- show login or logout options on account page
- register login screen in navigation and update docs

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a19c43549883318e108c3c9011efd4