### PR TITLE
Fix Google auth redirect for Android APK

### DIFF
--- a/frontend/src/components/NotificationHandler.jsx
+++ b/frontend/src/components/NotificationHandler.jsx
@@ -6,7 +6,7 @@ const NotificationHandler = () => {
 
   useEffect(() => {
     const handleNewMessage = (event) => {
-      const { title, body, data } = event.detail;
+      const { title, body } = event.detail;
       
       // Show in-app notification or toast
       if ('Notification' in window && Notification.permission === 'granted') {

--- a/frontend/src/firebase.js
+++ b/frontend/src/firebase.js
@@ -32,12 +32,13 @@ isSupported().then((supported) => {
 
 // ✅ Configure Google Provider
 const googleProvider = new GoogleAuthProvider();
-googleProvider.setCustomParameters({ 
+googleProvider.setCustomParameters({
   prompt: 'select_account',
   // Add mobile-specific parameters
   ...(window.Capacitor && {
     // For mobile apps, we need to handle redirects differently
-    redirect_uri: window.location.origin
+    // Use the custom scheme defined in AndroidManifest for OAuth redirects
+    redirect_uri: 'com.orirot.givit://oauth2redirect'
   })
 });
 


### PR DESCRIPTION
## Summary
- Use Android custom OAuth redirect scheme so Google sign-in works in APK builds
- Remove unused variable from NotificationHandler to satisfy lint

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a233b525a88331a3c4436edd173a11