### PR TITLE
Use shared app icon for web and Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ serviceAccountKey.json
 *.sln
 *.sw?
 uploads/
+frontend/public/icon.png

--- a/frontend/generate-icons.js
+++ b/frontend/generate-icons.js
@@ -2,17 +2,15 @@ import sharp from 'sharp';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { Buffer } from 'buffer';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// Load SVG content from resources/givit.svg so the app icon matches the provided asset
-const svgPath = path.join(__dirname, 'resources', 'givit.svg');
-if (!fs.existsSync(svgPath)) {
-  throw new Error(`SVG not found at: ${svgPath}`);
+// Load the base PNG icon that should be used for the app
+const iconPath = path.join(__dirname, 'resources', 'icon.png');
+if (!fs.existsSync(iconPath)) {
+  throw new Error(`Icon not found at: ${iconPath}`);
 }
-const svgContent = fs.readFileSync(svgPath, 'utf8');
 
 // Android icon sizes for different densities
 const iconSizes = {
@@ -25,6 +23,13 @@ const iconSizes = {
 
 // Create icons for each density
 async function generateIcons() {
+  const publicPath = path.join(__dirname, 'public');
+  if (!fs.existsSync(publicPath)) {
+    fs.mkdirSync(publicPath, { recursive: true });
+  }
+  fs.copyFileSync(iconPath, path.join(publicPath, 'icon.png'));
+  console.log('Copied web icon to public/icon.png');
+
   const androidResPath = path.join(__dirname, 'android', 'app', 'src', 'main', 'res');
   
   for (const [folder, size] of Object.entries(iconSizes)) {
@@ -36,19 +41,19 @@ async function generateIcons() {
     }
     
     // Generate ic_launcher.png
-    await sharp(Buffer.from(svgContent))
+    await sharp(iconPath)
       .resize(size, size)
       .png()
       .toFile(path.join(folderPath, 'ic_launcher.png'));
-    
+
     // Generate ic_launcher_round.png (same as regular for now)
-    await sharp(Buffer.from(svgContent))
+    await sharp(iconPath)
       .resize(size, size)
       .png()
       .toFile(path.join(folderPath, 'ic_launcher_round.png'));
-    
+
     // Generate ic_launcher_foreground.png (same as regular for now)
-    await sharp(Buffer.from(svgContent))
+    await sharp(iconPath)
       .resize(size, size)
       .png()
       .toFile(path.join(folderPath, 'ic_launcher_foreground.png'));

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,6 +10,7 @@
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Assistant:wght@400;700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Alef:wght@400;700&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="icon" type="image/png" href="/icon.png">
     <title>Giveit</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- Add web favicon link and generate icon during build
- Generate Android launcher icons from shared PNG
- Ignore generated web icon to avoid committing binaries

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a23c410c948331b040e2e551c554e0