### PR TITLE
Fix Android Google sign-in configuration

### DIFF
--- a/frontend/android/app/src/main/java/com/orirot/givit/MainActivity.java
+++ b/frontend/android/app/src/main/java/com/orirot/givit/MainActivity.java
@@ -3,13 +3,15 @@ package com.orirot.givit;
 import android.os.Bundle;
 import com.getcapacitor.BridgeActivity;
 import com.capacitorjs.plugins.pushnotifications.PushNotificationsPlugin;
+import com.codetrixstudio.capacitor.GoogleAuth.GoogleAuth;
 
 public class MainActivity extends BridgeActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         
-        // Register push notifications plugin
+        // Register native plugins
         registerPlugin(PushNotificationsPlugin.class);
+        registerPlugin(GoogleAuth.class);
     }
 }

--- a/frontend/android/app/src/main/res/values/strings.xml
+++ b/frontend/android/app/src/main/res/values/strings.xml
@@ -4,7 +4,8 @@
     <string name="title_activity_main">Givit</string>
     <string name="package_name">com.orirot.givit</string>
     <string name="custom_url_scheme">com.orirot.givit</string>
-    <!-- 
+    <string name="server_client_id">552189348251-93esjcu95at9ji45ugnddd60nistmqb6.apps.googleusercontent.com</string>
+    <!--
     IMPORTANT: Replace YOUR_API_KEY_HERE with your actual Google Maps API key
     Get it from: https://console.cloud.google.com/apis/credentials
     Make sure to enable Maps JavaScript API and Android Maps SDK

--- a/frontend/capacitor.config.json
+++ b/frontend/capacitor.config.json
@@ -23,6 +23,10 @@
     },
     "PushNotifications": {
       "presentationOptions": ["badge", "sound", "alert"]
+    },
+    "GoogleAuth": {
+      "scopes": ["profile", "email"],
+      "androidClientId": "552189348251-93esjcu95at9ji45ugnddd60nistmqb6.apps.googleusercontent.com"
     }
   },
   "android": {

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -210,8 +210,10 @@ export const AuthProvider = ({ children }) => {
       if (isMobileWebView()) {
         console.log('Using native Google sign-in for mobile');
         const { GoogleAuth } = await import('@codetrix-studio/capacitor-google-auth');
-
-        await GoogleAuth.initialize();
+        await GoogleAuth.initialize({
+          clientId: '552189348251-93esjcu95at9ji45ugnddd60nistmqb6.apps.googleusercontent.com',
+          scopes: ['profile', 'email']
+        });
         const googleUser = await GoogleAuth.signIn();
         const credential = GoogleAuthProvider.credential(googleUser.authentication.idToken);
         const userCredential = await signInWithCredential(auth, credential);


### PR DESCRIPTION
## Summary
- configure GoogleAuth plugin with Android web client ID
- register GoogleAuth plugin and initialize with client ID and scopes
- expose server_client_id for native builds

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a348193948833188f05a7b380599f0