### PR TITLE
feat(android): propagate sender info with push notifications

### DIFF
--- a/frontend/android/app/src/main/java/com/orirot/givit/FirebaseMessagingService.java
+++ b/frontend/android/app/src/main/java/com/orirot/givit/FirebaseMessagingService.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.os.Build;
 import androidx.core.app.NotificationCompat;
 import com.google.firebase.messaging.RemoteMessage;
+import java.util.Map;
 
 public class FirebaseMessagingService extends com.google.firebase.messaging.FirebaseMessagingService {
     private static final String CHANNEL_ID = "giveit_messages";
@@ -21,12 +22,16 @@ public class FirebaseMessagingService extends com.google.firebase.messaging.Fire
     public void onMessageReceived(RemoteMessage remoteMessage) {
         super.onMessageReceived(remoteMessage);
         
-        String title = remoteMessage.getNotification() != null ? 
+        String title = remoteMessage.getNotification() != null ?
             remoteMessage.getNotification().getTitle() : "New Message";
-        String body = remoteMessage.getNotification() != null ? 
+        String body = remoteMessage.getNotification() != null ?
             remoteMessage.getNotification().getBody() : "You have a new message";
-            
-        showNotification(title, body);
+
+        Map<String, String> data = remoteMessage.getData();
+        String senderId = data.get("senderId");
+        String senderName = data.get("senderName");
+
+        showNotification(title, body, senderId, senderName);
     }
 
     @Override
@@ -36,10 +41,16 @@ public class FirebaseMessagingService extends com.google.firebase.messaging.Fire
         sendTokenToServer(token);
     }
 
-    private void showNotification(String title, String body) {
+    private void showNotification(String title, String body, String senderId, String senderName) {
         Intent intent = new Intent(this, MainActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
         intent.putExtra("openMessages", true);
+        if (senderId != null) {
+            intent.putExtra("senderId", senderId);
+        }
+        if (senderName != null) {
+            intent.putExtra("senderName", senderName);
+        }
         
         PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, intent,
             PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);

--- a/frontend/android/app/src/main/java/com/orirot/givit/MainActivity.java
+++ b/frontend/android/app/src/main/java/com/orirot/givit/MainActivity.java
@@ -20,10 +20,26 @@ public class MainActivity extends BridgeActivity {
     }
 
     private void handleNotificationIntent(Intent intent) {
-        if (intent != null && intent.getBooleanExtra("openMessages", false)) {
+        if (intent == null) {
+            return;
+        }
+
+        boolean openMessages = intent.getBooleanExtra("openMessages", false);
+        String senderId = intent.getStringExtra("senderId");
+        String senderName = intent.getStringExtra("senderName");
+
+        if (openMessages || senderId != null) {
             JSObject data = new JSObject();
-            data.put("action", "openMessages");
-            
+            if (openMessages) {
+                data.put("action", "openMessages");
+            }
+            if (senderId != null) {
+                data.put("senderId", senderId);
+                if (senderName != null) {
+                    data.put("senderName", senderName);
+                }
+            }
+
             if (getBridge() != null) {
                 getBridge().triggerJSEvent("notificationTapped", "window", data.toString());
             }

--- a/frontend/src/services/notificationService.js
+++ b/frontend/src/services/notificationService.js
@@ -48,12 +48,10 @@ class NotificationService {
 
     // Listen for deep link events from MainActivity
     window.addEventListener('notificationTapped', (event) => {
-      if (event.detail?.action === 'openMessages') {
-        const customEvent = new CustomEvent('notificationTap', {
-          detail: { data: { action: 'openMessages' } }
-        });
-        window.dispatchEvent(customEvent);
-      }
+      const customEvent = new CustomEvent('notificationTap', {
+        detail: { data: event.detail }
+      });
+      window.dispatchEvent(customEvent);
     });
   }
 


### PR DESCRIPTION
## Summary
- forward sender metadata from FCM messages into the Android notification intent
- emit notification tap events with conversation details
- relay native notification tap events through the web notification service

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: lint errors in unrelated files)*
- `npx eslint src/services/notificationService.js`
- `./gradlew test` *(incomplete: Gradle distribution download only)*

------
https://chatgpt.com/codex/tasks/task_e_68b8167ebd3c8331b17cdad757076bbe