### PR TITLE
Add message button with unread indicator

### DIFF
--- a/frontend/src/components/Messages.jsx
+++ b/frontend/src/components/Messages.jsx
@@ -15,6 +15,11 @@ const Messages = ({ userId }) => {
   const location = useLocation();
   const navigate = useNavigate();
 
+  useEffect(() => {
+    localStorage.removeItem('hasNewMessages');
+    window.dispatchEvent(new Event('messagesRead'));
+  }, []);
+
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   };

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,5 +1,5 @@
+import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { GoHome, GoTools } from "react-icons/go";
 import { BsViewList } from "react-icons/bs";
 import { VscAccount } from "react-icons/vsc";
 import { AiOutlineMessage } from "react-icons/ai";
@@ -15,11 +15,44 @@ function Navbar() {
   const location = useLocation();
   const { user } = useAuthContext();
   const { t } = useTranslation();
+  const [hasNewMessages, setHasNewMessages] = useState(false);
+
+  useEffect(() => {
+    const handleNewMessage = () => {
+      if (location.pathname !== '/messages') {
+        localStorage.setItem('hasNewMessages', 'true');
+        setHasNewMessages(true);
+      }
+    };
+    const handleMessagesRead = () => {
+      localStorage.removeItem('hasNewMessages');
+      setHasNewMessages(false);
+    };
+
+    if (localStorage.getItem('hasNewMessages') === 'true') {
+      setHasNewMessages(true);
+    }
+
+    window.addEventListener('newMessage', handleNewMessage);
+    window.addEventListener('messagesRead', handleMessagesRead);
+
+    return () => {
+      window.removeEventListener('newMessage', handleNewMessage);
+      window.removeEventListener('messagesRead', handleMessagesRead);
+    };
+  }, [location.pathname]);
+
+  useEffect(() => {
+    if (location.pathname === '/messages') {
+      localStorage.removeItem('hasNewMessages');
+      setHasNewMessages(false);
+    }
+  }, [location.pathname]);
 
   const tabs = [
     { icon: <RiUserSettingsLine />, path: '/', label: t('navigation.services') },
     { icon: <FiPackage />, path: '/rentals', label: t('navigation.rentals') },
-    //{ icon: <AiOutlineMessage />, path: '/messages', label: t('navigation.messages') },
+    { icon: <AiOutlineMessage />, path: '/messages', label: t('navigation.messages') },
     { icon: <BsViewList />, path: '/my-items', label: t('navigation.my_items') },
     { icon: <VscAccount />, path: user ? '/dashboard' : '/account', label: t('navigation.account') },
   ];
@@ -34,6 +67,7 @@ function Navbar() {
           aria-label={tab.label}
         >
           {tab.icon}
+          {tab.path === '/messages' && hasNewMessages && <span className="notification-dot" />}
           <span className="nav-label">{tab.label}</span>
         </button>
       ))}

--- a/frontend/src/styles/components/Navbar.css
+++ b/frontend/src/styles/components/Navbar.css
@@ -43,6 +43,7 @@
     border-bottom: 2px solid transparent;
     transition: border-color 0.3s;
     gap: 0.25rem;
+    position: relative;
 }
 
 .nav-tab.active {
@@ -82,4 +83,14 @@
     .nav-tab {
         padding: 0.4rem;
     }
+}
+
+.notification-dot {
+    position: absolute;
+    top: 6px;
+    right: 18px;
+    width: 8px;
+    height: 8px;
+    background-color: #ff0000;
+    border-radius: 50%;
 }


### PR DESCRIPTION
## Summary
- show Messages tab in navbar
- display notification dot on Messages when new messages arrive
- clear notification indicator on Messages page load

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 12 errors, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68baefb8fbac8331bb96edc90e25a018