### PR TITLE
feat: add unread message tracking with push notifications

### DIFF
--- a/backend/models/Conversation.js
+++ b/backend/models/Conversation.js
@@ -1,0 +1,20 @@
+const mongoose = require('mongoose');
+
+const conversationSchema = new mongoose.Schema({
+  participants: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true }],
+  pairKey: { type: String, unique: true },
+}, { timestamps: true });
+
+conversationSchema.pre('validate', function(next) {
+  if (!this.participants || this.participants.length !== 2) {
+    return next(new Error('Conversation must have exactly 2 participants'));
+  }
+  const sorted = this.participants.map(id => id.toString()).sort();
+  this.pairKey = `${sorted[0]}:${sorted[1]}`;
+  this.participants = sorted; // store sorted to keep ordering
+  next();
+});
+
+conversationSchema.index({ pairKey: 1 }, { unique: true });
+
+module.exports = mongoose.model('Conversation', conversationSchema);

--- a/backend/models/ConversationParticipant.js
+++ b/backend/models/ConversationParticipant.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+const conversationParticipantSchema = new mongoose.Schema({
+  conversationId: { type: mongoose.Schema.Types.ObjectId, ref: 'Conversation', required: true },
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  lastReadAt: { type: Date, default: new Date(0) },
+}, { timestamps: true });
+
+conversationParticipantSchema.index({ conversationId: 1, userId: 1 }, { unique: true });
+
+module.exports = mongoose.model('ConversationParticipant', conversationParticipantSchema);

--- a/backend/models/Message.js
+++ b/backend/models/Message.js
@@ -1,26 +1,12 @@
 const mongoose = require('mongoose');
 
 const messageSchema = new mongoose.Schema({
-  senderId: {
-    type: String,
-    required: true,
-  },
-  receiverId: {
-    type: String,
-    required: true,
-  },
-  content: {
-    type: String,
-    required: true,
-  },
-  timestamp: {
-    type: Date,
-    default: Date.now,
-  },
-  isRead: {
-    type: Boolean,
-    default: false,
-  },
+  conversationId: { type: mongoose.Schema.Types.ObjectId, ref: 'Conversation', required: true, index: true },
+  senderId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  content: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now },
 });
+
+messageSchema.index({ conversationId: 1, createdAt: 1 });
 
 module.exports = mongoose.model('Message', messageSchema);

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -1,5 +1,11 @@
 const mongoose = require('mongoose');
 
+const pushTokenSchema = new mongoose.Schema({
+  token: { type: String, required: true },
+  platform: { type: String, enum: ['ios', 'android'], required: true },
+  updatedAt: { type: Date, default: Date.now },
+}, { _id: false });
+
 const userSchema = new mongoose.Schema({
     firebaseUid: { type: String, required: true, unique: true },
     firstName: { type: String },
@@ -12,7 +18,7 @@ const userSchema = new mongoose.Schema({
     photoURL:  { type: String },
     displayName: { type: String },
     photoUrl: { type: String },
-    fcmToken: { type: String },
+    pushTokens: [pushTokenSchema],
     createdAt: { type: Date, default: Date.now },
 }, {
     timestamps: true,

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@firebasegen/default-connector": "file:dataconnect-generated/js/default-connector",
         "@react-google-maps/api": "^2.20.6",
+        "apn": "^2.2.0",
         "axios": "^1.10.0",
         "bcryptjs": "^3.0.2",
         "compression": "^1.8.1",
@@ -25,6 +26,7 @@
         "mongoose": "^8.13.2",
         "multer": "^1.4.5-lts.2",
         "nodemon": "^3.1.9",
+        "redis": "^4.6.7",
         "socket.io": "^4.8.1",
         "styled-components": "^6.1.16"
       }
@@ -1168,6 +1170,65 @@
       "resolved": "https://registry.npmjs.org/@react-google-maps/marker-clusterer/-/marker-clusterer-2.20.0.tgz",
       "integrity": "sha512-tieX9Va5w1yP88vMgfH1pHTacDQ9TgDTjox3tLlisKDXRQWdjw+QeVVghhf5XqqIxXHgPdcGwBvKY6UP+SIvLw=="
     },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
     "node_modules/@schematics/angular": {
       "version": "19.2.15",
       "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-19.2.15.tgz",
@@ -1666,6 +1727,77 @@
         "node": ">= 8"
       }
     },
+    "node_modules/apn": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/apn/-/apn-2.2.0.tgz",
+      "integrity": "sha512-YIypYzPVJA9wzNBLKZ/mq2l1IZX/2FadPvwmSv4ZeR0VH7xdNITQ6Pucgh0Uw6ZZKC+XwheaJ57DFZAhJ0FvPg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.1.0",
+        "http2": "https://github.com/node-apn/node-http2/archive/apn-2.1.4.tar.gz",
+        "jsonwebtoken": "^8.1.0",
+        "node-forge": "^0.7.1",
+        "verror": "^1.10.0"
+      },
+      "engines": {
+        "node": ">= 4.6.0"
+      }
+    },
+    "node_modules/apn/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/apn/node_modules/jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=4",
+        "npm": ">=1.4.28"
+      }
+    },
+    "node_modules/apn/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/apn/node_modules/node-forge": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
+      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/apn/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/append-field": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
@@ -1683,6 +1815,15 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/async-retry": {
@@ -2036,6 +2177,15 @@
       "peer": true,
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/color-convert": {
@@ -2502,6 +2652,15 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
+    "node_modules/extsprintf": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT"
+    },
     "node_modules/farmhash-modern": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/farmhash-modern/-/farmhash-modern-1.1.0.tgz",
@@ -2777,6 +2936,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/get-caller-file": {
@@ -3232,6 +3400,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "optional": true
+    },
+    "node_modules/http2": {
+      "version": "3.3.6",
+      "resolved": "https://github.com/node-apn/node-http2/archive/apn-2.1.4.tar.gz",
+      "integrity": "sha512-ad4u4I88X9AcUgxCRW3RLnbh7xHWQ1f5HbrXa7gEy2x4Xgq+rq+auGx5I+nUDE2YYuqteGIlbxrwQXkIaYTfnQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
@@ -4369,6 +4546,23 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -5039,6 +5233,26 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/verror": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+      "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/verror/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "license": "MIT"
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@firebasegen/default-connector": "file:dataconnect-generated/js/default-connector",
     "@react-google-maps/api": "^2.20.6",
+    "apn": "^2.2.0",
     "axios": "^1.10.0",
     "bcryptjs": "^3.0.2",
     "compression": "^1.8.1",
@@ -22,11 +23,11 @@
     "firebase-admin": "^13.4.0",
     "framer-motion": "^12.6.2",
     "jsonwebtoken": "^9.0.2",
-    "redis": "^4.6.7",
     "mongodb": "^6.15.0",
     "mongoose": "^8.13.2",
     "multer": "^1.4.5-lts.2",
     "nodemon": "^3.1.9",
+    "redis": "^4.6.7",
     "socket.io": "^4.8.1",
     "styled-components": "^6.1.16"
   },

--- a/backend/routes/conversationRoutes.js
+++ b/backend/routes/conversationRoutes.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const { protect } = require('../middleware/authMiddleware');
+const { listConversations, markAsRead, unreadTotal } = require('../controllers/messageController');
+
+const router = express.Router();
+
+router.get('/', protect, listConversations);
+router.get('/unread-total', protect, unreadTotal);
+router.post('/:conversationId/read', protect, markAsRead);
+
+module.exports = router;

--- a/backend/routes/messageRoutes.js
+++ b/backend/routes/messageRoutes.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const { protect } = require('../middleware/authMiddleware');
+const { getMessagesHttp, sendMessageHttp } = require('../controllers/messageController');
+
+const router = express.Router();
+
+router.get('/:conversationId', protect, getMessagesHttp);
+router.post('/', protect, sendMessageHttp);
+
+module.exports = router;

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -42,22 +42,27 @@ router.put('/profile', protect, async (req, res) => {
   }
 });
 
-// Update FCM token
-router.post('/fcm-token', protect, async (req, res) => {
+// Save push token (FCM or APNs)
+router.post('/push-token', protect, async (req, res) => {
   try {
-    const { fcmToken } = req.body;
-    
-    const user = await User.findOneAndUpdate(
-      { firebaseUid: req.user.uid },
-      { fcmToken },
-      { new: true }
-    );
-    
+    const { token, platform } = req.body;
+    if (!token || !platform) {
+      return res.status(400).json({ message: 'token and platform are required' });
+    }
+    const user = await User.findOne({ firebaseUid: req.user.uid });
     if (!user) {
       return res.status(404).json({ message: 'User not found' });
     }
-    
-    res.json({ message: 'FCM token updated successfully' });
+    const existing = user.pushTokens.find(
+      (t) => t.token === token && t.platform === platform
+    );
+    if (existing) {
+      existing.updatedAt = new Date();
+    } else {
+      user.pushTokens.push({ token, platform, updatedAt: new Date() });
+    }
+    await user.save();
+    res.json({ message: 'Push token saved' });
   } catch (error) {
     res.status(500).json({ message: 'Server error', error: error.message });
   }

--- a/backend/server.js
+++ b/backend/server.js
@@ -15,7 +15,9 @@ const serviceRoutes = require('./routes/serviceRoutes');
 const rentalRequestRoutes = require('./routes/rentalRequestRoutes');
 const serviceRequestRoutes = require('./routes/serviceRequestRoutes');
 const userRoutes = require('./routes/userRoutes');
-const { loadMessages, sendMessage, getConversations, getMessages } = require('./controllers/messageController');
+const conversationRoutes = require('./routes/conversationRoutes');
+const messageRoutes = require('./routes/messageRoutes');
+const { sendMessage, getConversations, getMessages } = require('./controllers/messageController');
 const geocodeRoutes = require('./routes/geocodeRoutes');
 
 require('dotenv').config();
@@ -84,6 +86,8 @@ app.use('/api/service_requests', serviceRequestRoutes);
 app.use('/api/users', userRoutes);
 app.use('/api/test', require('./routes/testRoutes'));
 app.use('/api/geocode', geocodeRoutes);
+app.use('/api/conversations', conversationRoutes);
+app.use('/api/messages', messageRoutes);
 
 // Socket.IO
 io.on('connection', (socket) => {

--- a/backend/services/pushService.js
+++ b/backend/services/pushService.js
@@ -1,0 +1,97 @@
+const admin = require('firebase-admin');
+const apn = require('apn');
+const fs = require('fs');
+const path = require('path');
+const User = require('../models/User');
+const ConversationParticipant = require('../models/ConversationParticipant');
+const Message = require('../models/Message');
+
+let apnProvider = null;
+if (process.env.APNS_KEY_ID && process.env.APNS_TEAM_ID && process.env.APNS_KEY_PATH && process.env.APNS_BUNDLE_ID) {
+  try {
+    apnProvider = new apn.Provider({
+      token: {
+        key: fs.readFileSync(path.resolve(process.env.APNS_KEY_PATH)),
+        keyId: process.env.APNS_KEY_ID,
+        teamId: process.env.APNS_TEAM_ID,
+      },
+      production: process.env.NODE_ENV === 'production',
+    });
+  } catch (err) {
+    console.error('Failed to initialize APNs provider', err);
+  }
+}
+
+async function countUnreadTotal(userId) {
+  const participants = await ConversationParticipant.find({ userId });
+  let total = 0;
+  for (const p of participants) {
+    const count = await Message.countDocuments({
+      conversationId: p.conversationId,
+      senderId: { $ne: userId },
+      createdAt: { $gt: p.lastReadAt || new Date(0) },
+    });
+    total += count;
+  }
+  return total;
+}
+
+class PushService {
+  async sendMessageNotification(toUserId, fromUserId, messageContent) {
+    const toUser = await User.findById(toUserId);
+    const fromUser = await User.findById(fromUserId);
+    if (!toUser || !fromUser || !toUser.pushTokens || toUser.pushTokens.length === 0) {
+      return;
+    }
+    const unreadTotal = await countUnreadTotal(toUserId);
+    const senderName = `${fromUser.firstName || ''} ${fromUser.lastName || ''}`.trim() || 'Someone';
+    const truncated = messageContent.length > 100 ? messageContent.substring(0, 100) + '...' : messageContent;
+
+    for (const tokenInfo of toUser.pushTokens) {
+      if (tokenInfo.platform === 'android') {
+        const payload = {
+          token: tokenInfo.token,
+          data: {
+            title: senderName,
+            body: truncated,
+            senderId: fromUserId.toString(),
+            senderName,
+            type: 'message',
+            unread_total: unreadTotal.toString(),
+          },
+          android: {
+            notification: {
+              title: senderName,
+              body: truncated,
+            },
+          },
+        };
+        try {
+          await admin.messaging().send(payload);
+        } catch (err) {
+          console.error('Error sending FCM message', err);
+        }
+      } else if (tokenInfo.platform === 'ios' && apnProvider) {
+        const note = new apn.Notification({
+          alert: { title: senderName, body: truncated },
+          badge: unreadTotal,
+          sound: 'default',
+          payload: {
+            senderId: fromUserId.toString(),
+            senderName,
+            type: 'message',
+            unread_total: unreadTotal,
+          },
+        });
+        note.topic = process.env.APNS_BUNDLE_ID;
+        try {
+          await apnProvider.send(note, tokenInfo.token);
+        } catch (err) {
+          console.error('Error sending APNs message', err);
+        }
+      }
+    }
+  }
+}
+
+module.exports = new PushService();


### PR DESCRIPTION
## Summary
- add conversations and participants models with per-user read timestamps
- track unread counts and global badge totals via new controller logic and routes
- send FCM and APNs push notifications with unread totals

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd183acc488331ad19626d2a8c9ce7