### PR TITLE
Fix duplicate conversation participant import

### DIFF
--- a/backend/controllers/messageController.js
+++ b/backend/controllers/messageController.js
@@ -1,9 +1,6 @@
 const ConversationModel = require('../models/Conversation');
-
 const ConversationParticipant = require('../models/ConversationParticipant');
 const Message = require('../models/Message');
-const Conversation = require('../models/Conversation');
-const ConversationParticipant = require('../models/ConversationParticipant');
 const User = require('../models/User');
 const pushService = require('../services/pushService');
 


### PR DESCRIPTION
## Summary
- remove duplicate ConversationParticipant import from message controller

## Testing
- `npm test` *(fails: npm not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd45adc0883318e416f92cdd1635f