### PR TITLE
feat: add bilingual category hierarchy

### DIFF
--- a/frontend/src/components/HomePage/FilterButton.jsx
+++ b/frontend/src/components/HomePage/FilterButton.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
-import { VscFilter } from "react-icons/vsc";
-import { rentalCategories, serviceCategories } from "../../constants/categories";
+import { getRentalFilterTags, getServiceFilterTags } from "../../constants/categories";
 import '../../styles/HomePage/FilterButton.css'
 import { CiCircleRemove } from "react-icons/ci";
 import { BiFilterAlt } from "react-icons/bi";
@@ -13,11 +12,15 @@ const FilterButton = ({ onApplyFilters, categoryType }) => {
   const [selectedCategories, setSelectedCategories] = useState([]);
 
   const availableCategories =
-    categoryType === "rental" ? rentalCategories : serviceCategories;
+    categoryType === "rental"
+      ? getRentalFilterTags(i18n.language)
+      : getServiceFilterTags(i18n.language);
 
   const toggleCategory = (cat) => {
     setSelectedCategories((prev) =>
-      prev.includes(cat) ? prev.filter((c) => c !== cat) : [...prev, cat]
+      prev.includes(cat)
+        ? prev.filter((c) => c !== cat)
+        : [...prev, cat]
     );
   };
 
@@ -46,13 +49,13 @@ const FilterButton = ({ onApplyFilters, categoryType }) => {
               <div className="categories-container">
                 {availableCategories.map((cat) => (
                   <button
-                    key={cat}
-                    onClick={() => toggleCategory(cat)}
+                    key={cat.value}
+                    onClick={() => toggleCategory(cat.value)}
                     className={`category-btn ${
-                      selectedCategories.includes(cat) ? "selected" : ""
+                      selectedCategories.includes(cat.value) ? "selected" : ""
                     }`}
                   >
-                    {cat}
+                    {cat.label}
                   </button>
                 ))}
               </div>

--- a/frontend/src/components/HomePage/GenericMapPage.jsx
+++ b/frontend/src/components/HomePage/GenericMapPage.jsx
@@ -10,6 +10,7 @@ import SearchBar from "./SearchBar";
 import '../../styles/HomePage/GenericMapPage.css';
 import { handleSearch as searchItems } from "./searchHelpers";
 import { useTranslation } from 'react-i18next';
+import { getRentalFilterTags, getServiceFilterTags } from "../../constants/categories";
 import { useNavigate } from 'react-router-dom';
 import { useMapContext } from '../../context/MapContext';
 
@@ -969,37 +970,10 @@ const GenericMapPage = ({ apiUrl }) => {
 
     // Get available categories based on contentType
     const availableCategories = useMemo(() => {
-        return contentType.includes('rental') ?
-            [
-                'Tools',
-                'Electronics',
-                'Vehicles',
-                'Sports',
-                'Furniture',
-                'Clothes',
-                'Other',
-            ] : [
-                'Repair',
-                'Cleaning',
-                'Tutoring',
-                'Moving',
-                'Pet Care',
-                'Beauty',
-                'Other',
-            ];
-    }, [contentType]);
-
-    // Get translated label for each category
-    const getCategoryLabel = (cat) => {
-        if (i18n.language === 'he') {
-            if (contentType.includes('rental')) {
-                return t(`categories.rental.${cat}`);
-            } else {
-                return t(`categories.service.${cat}`);
-            }
-        }
-        return cat;
-    };
+        return contentType.includes('rental')
+            ? getRentalFilterTags(i18n.language)
+            : getServiceFilterTags(i18n.language);
+    }, [contentType, i18n.language]);
 
     // Category label click handler
     const handleCategoryLabelClick = (cat) => {
@@ -1359,11 +1333,11 @@ const GenericMapPage = ({ apiUrl }) => {
                                     <div className="floating-category-labels">
                                         {availableCategories.map((cat) => (
                                             <span
-                                                key={cat}
-                                                className={`category-label${selectedCategory === cat ? ' selected' : ''}`}
-                                                onClick={() => handleCategoryLabelClick(cat)}
+                                                key={cat.value}
+                                                className={`category-label${selectedCategory === cat.value ? ' selected' : ''}`}
+                                                onClick={() => handleCategoryLabelClick(cat.value)}
                                             >
-                                                {getCategoryLabel(cat)}
+                                                {cat.label}
                                             </span>
                                         ))}
                                     </div>

--- a/frontend/src/components/MyItems/EditModal.jsx
+++ b/frontend/src/components/MyItems/EditModal.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import '../../styles/components/Modal.css';
-import { rentalCategories, serviceCategories } from '../../constants/categories';
+import { getRentalTagOptions, getServiceTagOptions } from '../../constants/categories';
 import { geocodeAddress } from '../HomePage/geocode';
 
 const EditModal = ({ item, type, onSave, onCancel }) => {
@@ -39,7 +39,10 @@ const EditModal = ({ item, type, onSave, onCancel }) => {
         onSave(updatedForm);
     };
 
-    const categoryOptions = type === 'rental' ? rentalCategories : serviceCategories;
+    const categoryOptions =
+        type === 'rental'
+            ? getRentalTagOptions(i18n.language)
+            : getServiceTagOptions(i18n.language);
 
     return (
         <div className="modal">
@@ -61,8 +64,8 @@ const EditModal = ({ item, type, onSave, onCancel }) => {
                 <select name="category" value={form.category} onChange={handleChange}>
                     <option value="">{t('common.select_category')}</option>
                     {categoryOptions.map((category) => (
-                        <option key={category} value={category}>
-                            {category}
+                        <option key={category.value} value={category.value}>
+                            {category.label}
                         </option>
                     ))}
                 </select>

--- a/frontend/src/components/RequestRental/RequestRentalForm.jsx
+++ b/frontend/src/components/RequestRental/RequestRentalForm.jsx
@@ -1,18 +1,18 @@
 import { useAuthContext } from '../../context/AuthContext';
 import { useTranslation } from 'react-i18next';
 import ModalUploadForm from '../UploadForm/ModalUploadForm';
-import { rentalCategories } from '../../constants/categories';
+import { getRentalTagOptions } from '../../constants/categories';
 
 const RequestRentalForm = () => {
     const { user } = useAuthContext();
-    const { t } = useTranslation();
+    const { t, i18n } = useTranslation();
     const baseUrl = import.meta.env.VITE_API_URL || 'https://giveit-backend.onrender.com';
 
     return (
         <ModalUploadForm
             user={user}
             titleText={t('forms.request_rental_title')}
-            categories={rentalCategories.map(cat => t(`categories.rental.${cat}`))}
+            categories={getRentalTagOptions(i18n.language)}
             submitUrl={`${baseUrl}/api/rental_requests`}
             successMessage={t('forms.request_rental_success')}
             submitButtonText={t('forms.submit_request')}

--- a/frontend/src/components/RequestService/RequestServiceForm.jsx
+++ b/frontend/src/components/RequestService/RequestServiceForm.jsx
@@ -1,18 +1,18 @@
 import { useAuthContext } from '../../context/AuthContext';
 import { useTranslation } from 'react-i18next';
 import ModalUploadForm from '../UploadForm/ModalUploadForm';
-import { serviceCategories } from '../../constants/categories';
+import { getServiceTagOptions } from '../../constants/categories';
 
 const RequestServiceForm = () => {
     const { user } = useAuthContext();
-    const { t } = useTranslation();
+    const { t, i18n } = useTranslation();
     const baseUrl = import.meta.env.VITE_API_URL || 'https://giveit-backend.onrender.com';
 
     return (
         <ModalUploadForm
             user={user}
             titleText={t('forms.request_service_title')}
-            categories={serviceCategories.map(cat => t(`categories.service.${cat}`))}
+            categories={getServiceTagOptions(i18n.language)}
             submitUrl={`${baseUrl}/api/service_requests`}
             successMessage={t('forms.request_service_success')}
             submitButtonText={t('forms.submit_request')}

--- a/frontend/src/components/UploadForm/ModalUploadForm.jsx
+++ b/frontend/src/components/UploadForm/ModalUploadForm.jsx
@@ -15,8 +15,9 @@ submitButtonText,
 user,
 }) => {
 const navigate = useNavigate();
-const { t } = useTranslation();
+const { t, i18n } = useTranslation();
 const { getPricePeriodOptions } = usePricePeriodTranslation();
+const isRTL = i18n.language === 'he';
 
 const [form, setForm] = useState({
     title: '',
@@ -108,7 +109,7 @@ const handleSubmit = async e => {
 };
 
 return (
-    <div className="upload-form-container" style={{ fontFamily: 'Heebo, Arial, sans-serif' }}>
+    <div className="upload-form-container" style={{ fontFamily: 'Heebo, Arial, sans-serif' }} dir={isRTL ? 'rtl' : 'ltr'}>
         {success ? (
             <div className="alert alert-success shadow-lg flex flex-col items-center">
                 <span className="text-lg font-semibold">{successMessage}</span>
@@ -132,7 +133,9 @@ return (
                     <div className="form-group">
                         <select name="category" value={form.category} onChange={handleChange} className="select select-bordered w-full" required>
                             <option value="">{t('forms.select_category')}</option>
-                            {categories.map((cat, index) => <option key={index} value={cat}>{cat}</option>)}
+                            {categories.map((cat) => (
+                                <option key={cat.value} value={cat.value}>{cat.label}</option>
+                            ))}
                         </select>
                     </div>
                     <div className="form-group">

--- a/frontend/src/components/UploadForm/RentalForm.jsx
+++ b/frontend/src/components/UploadForm/RentalForm.jsx
@@ -1,18 +1,18 @@
 import { useAuthContext } from '../../context/AuthContext';
 import { useTranslation } from 'react-i18next';
 import ModalUploadForm from './ModalUploadForm';
-import { rentalCategories } from '../../constants/categories';
+import { getRentalTagOptions } from '../../constants/categories';
 
 const RentalForm = () => {
     const { user } = useAuthContext();
-    const { t } = useTranslation();
+    const { t, i18n } = useTranslation();
     const baseUrl = import.meta.env.VITE_API_URL || 'https://giveit-backend.onrender.com';
 
     return (
         <ModalUploadForm
             user={user}
             titleText={t('forms.offer_rental_title')}
-            categories={rentalCategories.map(cat => t(`categories.rental.${cat}`))}
+            categories={getRentalTagOptions(i18n.language)}
             submitUrl={`${baseUrl}/api/rentals`}
             successMessage={t('forms.offer_rental_success')}
             submitButtonText={t('forms.submit_offer')}

--- a/frontend/src/components/UploadForm/ServiceForm.jsx
+++ b/frontend/src/components/UploadForm/ServiceForm.jsx
@@ -1,18 +1,18 @@
 import { useAuthContext } from '../../context/AuthContext';
 import { useTranslation } from 'react-i18next';
 import ModalUploadForm from './ModalUploadForm';
-import { serviceCategories } from '../../constants/categories';
+import { getServiceTagOptions } from '../../constants/categories';
 
 const ServiceForm = () => {
     const { user } = useAuthContext();
-    const { t } = useTranslation();
+    const { t, i18n } = useTranslation();
     const baseUrl = import.meta.env.VITE_API_URL || 'https://giveit-backend.onrender.com';
 
     return (
         <ModalUploadForm
             user={user}
             titleText={t('forms.offer_service_title')}
-            categories={serviceCategories.map(cat => t(`categories.service.${cat}`))}
+            categories={getServiceTagOptions(i18n.language)}
             submitUrl={`${baseUrl}/api/services/with-urls`}
             successMessage={t('forms.offer_service_success')}
             submitButtonText={t('forms.submit_offer')}

--- a/frontend/src/constants/categories.js
+++ b/frontend/src/constants/categories.js
@@ -1,22 +1,160 @@
-// Translation keys for i18n:
-// rental: categories.rental.Tools, categories.rental.Electronics, categories.rental.Vehicles, categories.rental.Sports, categories.rental.Furniture, categories.rental.Clothes, categories.rental.Other
-// service: categories.service.Repair, categories.service.Cleaning, categories.service.Tutoring, categories.service.Moving, categories.service.Pet Care, categories.service.Beauty, categories.service.Other
-export const rentalCategories = [
-    'Tools',
-    'Electronics',
-    'Vehicles',
-    'Sports',
-    'Furniture',
-    'Clothes',
-    'Other',
+// Bilingual category and tag definitions for rentals and services.
+// Each tag stores English and Hebrew labels along with a short label used in filters.
+
+// ---------------------- Service Categories ----------------------
+export const serviceCategoryData = [
+  {
+    en: 'Tutoring',
+    he: 'שיעורים',
+    tags: [
+      { en: 'Math', he: 'מתמטיקה', short: { en: 'Math', he: 'מתמטיקה' } },
+      { en: 'Programming', he: 'תכנות', short: { en: 'Prog', he: 'תכנות' } },
+      { en: 'Languages', he: 'שפות', short: { en: 'Lang', he: 'שפות' } },
+    ],
+  },
+  {
+    en: 'Summaries',
+    he: 'שיעורי בית',
+    tags: [
+      { en: 'Notes', he: 'סיכומים', short: { en: 'Notes', he: 'סיכומים' } },
+      { en: 'Seminar Papers', he: 'עבודות סמינר', short: { en: 'Seminar', he: 'סמינר' } },
+      { en: 'Editing', he: 'עריכה', short: { en: 'Edit', he: 'עריכה' } },
+    ],
+  },
+  {
+    en: 'Transport',
+    he: 'הובלה',
+    tags: [
+      { en: 'Small Moves', he: 'הובלות קטנות', short: { en: 'Moves', he: 'הובלה' } },
+      { en: 'Carpool', he: 'קארפול', short: { en: 'Carpool', he: 'קארפול' } },
+      { en: 'Errands', he: 'שליחויות', short: { en: 'Errands', he: 'שליח' } },
+    ],
+  },
+  {
+    en: 'Care',
+    he: 'טיפול',
+    tags: [
+      { en: 'Pets', he: 'חיות', short: { en: 'Pets', he: 'חיות' } },
+      { en: 'Plants', he: 'צמחים', short: { en: 'Plants', he: 'צמחים' } },
+      { en: 'Cleaning', he: 'ניקיון', short: { en: 'Clean', he: 'ניקיון' } },
+    ],
+  },
+  {
+    en: 'Tech Repairs',
+    he: 'תיקונים',
+    tags: [
+      { en: 'Computers', he: 'מחשבים', short: { en: 'PCs', he: 'מחשבים' } },
+      { en: 'Phones', he: 'טלפונים', short: { en: 'Phones', he: 'טלפונים' } },
+      { en: 'Software Help', he: 'עזרה בתוכנה', short: { en: 'Software', he: 'תוכנה' } },
+    ],
+  },
+  {
+    en: 'Events',
+    he: 'אירועים',
+    tags: [
+      { en: 'Photography', he: 'צילום', short: { en: 'Photo', he: 'צילום' } },
+      { en: 'Music/DJ', he: 'מוזיקה/תקליטן', short: { en: 'Music', he: 'מוזיקה' } },
+      { en: 'Organization', he: 'ארגון', short: { en: 'Org', he: 'ארגון' } },
+    ],
+  },
+  {
+    en: 'Beauty & Fitness',
+    he: 'יופי וכושר',
+    tags: [
+      { en: 'Hair', he: 'שיער', short: { en: 'Hair', he: 'שיער' } },
+      { en: 'Cosmetics', he: 'קוסמטיקה', short: { en: 'Cosmo', he: 'קוסמטיקה' } },
+      { en: 'Gym Coaching', he: 'אימון כושר', short: { en: 'Gym', he: 'אימון' } },
+    ],
+  },
 ];
 
-export const serviceCategories = [
-    'Repair',
-    'Cleaning',
-    'Tutoring',
-    'Moving',
-    'Pet Care',
-    'Beauty',
-    'Other',
+// ---------------------- Rental Categories ----------------------
+export const rentalCategoryData = [
+  {
+    en: 'Study Equipment',
+    he: 'ציוד לימודי',
+    tags: [
+      { en: 'Laptop', he: 'מחשב נייד', short: { en: 'Laptop', he: 'מחשב' } },
+      { en: 'Projector', he: 'מקרן', short: { en: 'Proj', he: 'מקרן' } },
+      { en: 'Calculator', he: 'מחשבון', short: { en: 'Calc', he: 'מחשבון' } },
+      { en: 'Books', he: 'ספרים', short: { en: 'Books', he: 'ספרים' } },
+    ],
+  },
+  {
+    en: 'Sports Equipment',
+    he: 'ציוד ספורט',
+    tags: [
+      { en: 'Balls', he: 'כדורים', short: { en: 'Balls', he: 'כדורים' } },
+      { en: 'Yoga Mat', he: 'מזרן יוגה', short: { en: 'Yoga', he: 'יוגה' } },
+      { en: 'Weights', he: 'משקולות', short: { en: 'Weights', he: 'משק' } },
+      { en: 'Rackets', he: 'מחבטים', short: { en: 'Rackets', he: 'מחבט' } },
+    ],
+  },
+  {
+    en: 'Home Items',
+    he: 'ציוד ביתי',
+    tags: [
+      { en: 'Kitchen Tools', he: 'כלי מטבח', short: { en: 'Kitchen', he: 'מטבח' } },
+      { en: 'Vacuum', he: 'שואב אבק', short: { en: 'Vacuum', he: 'שואב' } },
+      { en: 'Small Tools', he: 'כלי עבודה קטנים', short: { en: 'Tools', he: 'כלים' } },
+    ],
+  },
+  {
+    en: 'Transport',
+    he: 'תחבורה קלה',
+    tags: [
+      { en: 'Bicycle', he: 'אופניים', short: { en: 'Bike', he: 'אופניים' } },
+      { en: 'Scooter', he: 'קורקינט', short: { en: 'Scooter', he: 'קורק' } },
+      { en: 'Skateboard', he: 'סקייטבורד', short: { en: 'Skate', he: 'סקייט' } },
+    ],
+  },
+  {
+    en: 'Event Gear',
+    he: 'ציוד אירועים',
+    tags: [
+      { en: 'Speakers', he: 'רמקולים', short: { en: 'Speak', he: 'רמקול' } },
+      { en: 'Lights', he: 'אורות', short: { en: 'Lights', he: 'אורות' } },
+      { en: 'Cameras', he: 'מצלמות', short: { en: 'Camera', he: 'מצלמה' } },
+      { en: 'Board Games', he: 'משחקי שולחן', short: { en: 'Games', he: 'משחק' } },
+    ],
+  },
+  {
+    en: 'Entertainment',
+    he: 'פנאי ובידור',
+    tags: [
+      { en: 'Console', he: 'קונסולה', short: { en: 'Console', he: 'קונסולה' } },
+      { en: 'Novels', he: 'ספרי קריאה', short: { en: 'Novels', he: 'ספרים' } },
+      { en: 'Camping Gear', he: 'ציוד קמפינג', short: { en: 'Camping', he: 'קמפינג' } },
+    ],
+  },
 ];
+
+// ---------------------- Helper Functions ----------------------
+
+const flattenTags = (data) =>
+  data.flatMap((cat) => cat.tags.map((tag) => ({ ...tag })));
+
+export const getServiceTagOptions = (lang = 'en') =>
+  serviceCategoryData.flatMap((cat) =>
+    cat.tags.map((tag) => ({ value: tag.en, label: tag[lang] }))
+  );
+
+export const getRentalTagOptions = (lang = 'en') =>
+  rentalCategoryData.flatMap((cat) =>
+    cat.tags.map((tag) => ({ value: tag.en, label: tag[lang] }))
+  );
+
+export const getServiceFilterTags = (lang = 'en') =>
+  serviceCategoryData.flatMap((cat) =>
+    cat.tags.map((tag) => ({ value: tag.en, label: tag.short[lang] }))
+  );
+
+export const getRentalFilterTags = (lang = 'en') =>
+  rentalCategoryData.flatMap((cat) =>
+    cat.tags.map((tag) => ({ value: tag.en, label: tag.short[lang] }))
+  );
+
+// Export flattened tag lists (English values) for backend use if needed
+export const serviceTags = flattenTags(serviceCategoryData);
+export const rentalTags = flattenTags(rentalCategoryData);
+


### PR DESCRIPTION
## Summary
- add bilingual rental and service category data with subcategories and short tag labels
- update forms and filter to use dynamic language tags and RTL/LTR direction
- refresh map page to show localized filter tags

## Testing
- `cd backend && npm test` *(fails: Download failed for url "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-5.0.15.tgz")*
- `cd frontend && npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68be7c591c8083318ca61f13e0e86a1b