### PR TITLE
Fix image upload stuck state

### DIFF
--- a/frontend/src/components/ImageUpload.jsx
+++ b/frontend/src/components/ImageUpload.jsx
@@ -8,7 +8,9 @@ const ImageUpload = ({ onImageUpload, multiple = false, accept = 'image/*' }) =>
   const [error, setError] = useState('');
 
   const handleFileUpload = async (event) => {
-    const files = Array.from(event.target.files);
+    // Preserve a reference to the input in case React reuses the event object
+    const input = event.target;
+    const files = Array.from(input.files);
     if (files.length === 0) return;
 
     const auth = getAuth();
@@ -65,7 +67,8 @@ const ImageUpload = ({ onImageUpload, multiple = false, accept = 'image/*' }) =>
       setError(errorMessage);
     } finally {
       setUploading(false);
-      event.target.value = ''; // Reset input
+      // Reset the file input so the same file can be selected again
+      input.value = '';
     }
   };
 

--- a/frontend/src/components/UploadForm/ModalUploadForm.jsx
+++ b/frontend/src/components/UploadForm/ModalUploadForm.jsx
@@ -49,7 +49,6 @@ const [imageUrls, setImageUrls] = useState([]);
 const [success, setSuccess] = useState(false);
 const [error, setError] = useState(null);
 const [isSubmitting, setIsSubmitting] = useState(false);
-const [imageUploadError, setImageUploadError] = useState(null);
 
 
 const handleChange = e => {
@@ -63,7 +62,6 @@ const handleCategoryChange = e => {
 
 const handleImageUpload = (urls) => {
     setImageUrls(urls.slice(0, 5)); // Limit to 5 images
-    setImageUploadError(null); // Clear any previous upload errors
 };
 
 const handleSubmit = async e => {


### PR DESCRIPTION
## Summary
- handle file input reliably in ImageUpload component to prevent upload from stalling
- remove unused imageUploadError state from ModalUploadForm

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 'setSelectedCategory' is not defined)*
- `npx eslint src/components/ImageUpload.jsx src/components/UploadForm/ModalUploadForm.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68becc346cf08331ae1b3ea1da11f4d2