### PR TITLE
feat: preload map component

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import { useAuthContext } from './context/AuthContext';
 import { I18nextProvider } from 'react-i18next';
 import i18n from './i18n';
 import GoogleMapsLoader from './components/GoogleMapsLoader';
+import MapPreloader from './components/MapPreloader';
 import ErrorBoundary from './ErrorBoundary';
 import Layout from './components/Layout';
 import RentalsMapPage from './components/HomePage/RentalsMapPage';
@@ -53,6 +54,7 @@ function App() {
   return (
     <GoogleMapsLoader>
       <MapProvider>
+        <MapPreloader />
         <Router>
           <ErrorBoundary>
           <I18nextProvider i18n={i18n}>

--- a/frontend/src/components/MapPreloader.jsx
+++ b/frontend/src/components/MapPreloader.jsx
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+
+/**
+ * Preloads the MapView component in the background so it's ready
+ * when the user navigates to a map-based page. This helps reduce
+ * delays on initial map load without affecting the UI.
+ */
+const MapPreloader = () => {
+  useEffect(() => {
+    // Trigger background loading of the MapView module
+    import('./HomePage/MapView');
+  }, []);
+
+  return null;
+};
+
+export default MapPreloader;


### PR DESCRIPTION
## Summary
- preload MapView module on app start for faster map navigation
- integrate MapPreloader into App to kick off background loading

## Testing
- `npm run lint` *(fails: unused vars in existing files)*
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c07c50a140833194927a0258d038f3