### PR TITLE
Handle CORS preflight for uploads

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -63,10 +63,16 @@ app.get('/health', (req, res) => {
 
 // Middleware
 app.use(requestLogger);
-app.use(cors({
+const corsOptions = {
   origin: allowedOrigins,
   credentials: true,
-}));
+  methods: ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE'],
+  allowedHeaders: ['Content-Type', 'Authorization'],
+  optionsSuccessStatus: 200,
+};
+app.use(cors(corsOptions));
+// Handle preflight requests
+app.options('*', cors(corsOptions), (req, res) => res.sendStatus(200));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 


### PR DESCRIPTION
## Summary
- define reusable CORS options with allowed methods and headers
- reply to preflight requests with 200 status to prevent redirects

## Testing
- `npm test` *(fails: Download failed for url "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-5.0.15.tgz", Status Code is 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c080ea499c83318b6840bc63d74a5e