### PR TITLE
fix: avoid Firebase measurement ID mismatch

### DIFF
--- a/frontend/src/firebase.js
+++ b/frontend/src/firebase.js
@@ -11,7 +11,11 @@ const firebaseConfig = {
   storageBucket: "givitori.appspot.com", // תקן כאן, זה לא "firebasestorage.app"
   messagingSenderId: "552189348251",
   appId: "1:552189348251:web:482bdf4500beebe934b93e",
-  measurementId: "G-BQYJMH3X"
+  // measurementId is optional: if provided via env it will be used, otherwise
+  // Firebase will fetch it automatically to avoid mismatches.
+  ...(import.meta.env.VITE_FIREBASE_MEASUREMENT_ID && {
+    measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
+  }),
 };
 
 // ✅ Initialize Firebase only once


### PR DESCRIPTION
## Summary
- allow Firebase Analytics measurement ID to be supplied via environment variable or fetched automatically, preventing ID mismatch warnings

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 20 problems)


------
https://chatgpt.com/codex/tasks/task_e_68c08dca68748331aa4d929b03896fd2