### PR TITLE
feat: keep map loaded in background

### DIFF
--- a/frontend/src/components/HomePage/MapView.jsx
+++ b/frontend/src/components/HomePage/MapView.jsx
@@ -82,9 +82,8 @@ const MapView = ({ locations, mapHeight, onBoundsChanged, children, contentType 
     const [selectedItem, setSelectedItem] = useState(null);
     const [userLocation, setUserLocation] = useState(null);
     const [mapLoadError, setMapLoadError] = useState(false);
-    const [isMapLoaded, setIsMapLoaded] = useState(false);
     const [isAndroid, setIsAndroid] = useState(false);
-    const { mapRef } = useMapContext();
+    const { mapRef, isMapLoaded, setIsMapLoaded } = useMapContext();
     const hasSetInitialLocation = useRef(false);
     const memoizedLocations = useMemo(() => locations, [locations]);
 

--- a/frontend/src/components/MapPreloader.jsx
+++ b/frontend/src/components/MapPreloader.jsx
@@ -1,17 +1,40 @@
-import { useEffect } from 'react';
+import React, { Suspense } from 'react';
+import { useMapContext } from '../context/MapContext';
+
+// Lazy-load MapView so it doesn't impact the initial bundle size
+const MapView = React.lazy(() => import('./HomePage/MapView'));
 
 /**
- * Preloads the MapView component in the background so it's ready
- * when the user navigates to a map-based page. This helps reduce
- * delays on initial map load without affecting the UI.
+ * Renders a hidden MapView so that Google Maps is initialized in the
+ * background. This keeps the map warm and reduces perceived loading
+ * times when users navigate to pages that display the map.
  */
 const MapPreloader = () => {
-  useEffect(() => {
-    // Trigger background loading of the MapView module
-    import('./HomePage/MapView');
-  }, []);
+  const { locations, contentType } = useMapContext();
 
-  return null;
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        width: '1px',
+        height: '1px',
+        top: 0,
+        left: 0,
+        overflow: 'hidden',
+        pointerEvents: 'none',
+        opacity: 0,
+      }}
+      aria-hidden="true"
+    >
+      <Suspense fallback={null}>
+        <MapView
+          locations={locations}
+          mapHeight="1px"
+          contentType={contentType}
+        />
+      </Suspense>
+    </div>
+  );
 };
 
 export default MapPreloader;

--- a/frontend/src/context/MapContext.jsx
+++ b/frontend/src/context/MapContext.jsx
@@ -7,9 +7,10 @@ export const MapProvider = ({ children }) => {
   const mapRef = useRef(null);
   const [locations, setLocations] = useState([]);
   const [contentType, setContentType] = useState('services');
+  const [isMapLoaded, setIsMapLoaded] = useState(false);
 
   return (
-    <MapContext.Provider value={{ mapRef, locations, setLocations, contentType, setContentType }}>
+    <MapContext.Provider value={{ mapRef, locations, setLocations, contentType, setContentType, isMapLoaded, setIsMapLoaded }}>
       {children}
     </MapContext.Provider>
   );


### PR DESCRIPTION
## Summary
- render a hidden Google Map to warm up the API in the background
- share map load state via context so pages know when the map is ready
- use the shared flag inside MapView to avoid duplicate loading spinners

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 13 errors, 7 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68c699b5cfb88331828f92646f28db2e